### PR TITLE
NVIS-3710: Add bold styling to chart titles in two column chart and chart with description slides

### DIFF
--- a/lib/powerpoint/views/collision-wide/ff_trend_text_left_chart_right_slide.xml.erb
+++ b/lib/powerpoint/views/collision-wide/ff_trend_text_left_chart_right_slide.xml.erb
@@ -150,7 +150,7 @@
           <a:lstStyle/>
           <a:p>
             <a:r>
-              <a:rPr lang="en-GB"/>
+              <a:rPr lang="en-GB" dirty="0" b="1" />
               <a:t><%= !question_title.nil? ? question_title.strip.encode(:xml => :text) : '' %></a:t>
             </a:r>
           </a:p>

--- a/lib/powerpoint/views/collision-wide/ff_trend_text_right_chart_left_slide.xml.erb
+++ b/lib/powerpoint/views/collision-wide/ff_trend_text_right_chart_left_slide.xml.erb
@@ -150,7 +150,7 @@
           <a:lstStyle/>
           <a:p>
             <a:r>
-              <a:rPr lang="en-GB"/>
+              <a:rPr lang="en-GB" dirty="0" b="1" />
               <a:t><%= !question_title.nil? ? question_title.strip.encode(:xml => :text) : '' %></a:t>
             </a:r>
           </a:p>

--- a/lib/powerpoint/views/collision-wide/ff_trend_two_column_chart_slide.xml.erb
+++ b/lib/powerpoint/views/collision-wide/ff_trend_two_column_chart_slide.xml.erb
@@ -142,7 +142,7 @@
           <a:lstStyle/>
           <a:p>
             <a:r>
-              <a:rPr lang="en-GB"/>
+              <a:rPr lang="en-GB" dirty="0" b="1" />
               <a:t><%= @question_titles[0].strip.encode(:xml => :text) %></a:t>
             </a:r>
           </a:p>
@@ -214,7 +214,7 @@
           <a:lstStyle/>
           <a:p>
             <a:r>
-              <a:rPr lang="en-GB"/>
+              <a:rPr lang="en-GB" dirty="0" b="1" />
               <a:t><%= @question_titles[1].strip.encode(:xml => :text) %></a:t>
             </a:r>
           </a:p>


### PR DESCRIPTION
### [NVIS-3710: 50:50 data download template - bold chart titles](https://stylefoundry.atlassian.net/browse/NVIS-3710)