### PR TITLE
January sprint

### DIFF
--- a/lib/powerpoint.rb
+++ b/lib/powerpoint.rb
@@ -25,6 +25,7 @@ require 'powerpoint/slide/ff_trend_text_right_image_left'
 require 'powerpoint/slide/ff_trend_text_left_image_right'
 require 'powerpoint/slide/ff_trend_two_column_chart'
 require 'powerpoint/slide/ff_trend_two_column_text'
+require 'powerpoint/slide/ff_trend_summary'
 
 module Powerpoint
   ROOT_PATH = File.expand_path("../..", __FILE__)

--- a/lib/powerpoint/presentation.rb
+++ b/lib/powerpoint/presentation.rb
@@ -60,19 +60,29 @@ module Powerpoint
 
     def add_ff_heading_text_slide(title, content, image_paths, links = [])
       @slides << if image_paths&.any?
-        Powerpoint::Slide::FFTrendTextLeftImageRight.new(
-          presentation: self,
-          title: title,
-          content: content,
-          image_path: image_paths[0],
-          links: links
-        )
+        if content.length > 0
+          Powerpoint::Slide::FFTrendTextLeftImageRight.new(
+            presentation: self,
+            title: title,
+            content: content,
+            image_path: image_paths[0],
+            links: links
+          )
+        else
+          Powerpoint::Slide::FFTrendTextWithImage.new(
+            presentation: self,
+            title: title,
+            content: "",
+            image_paths: image_paths,
+            links: links
+          )
+        end
       else
         Powerpoint::Slide::FFTrendHeadingText.new(
           presentation: self,
           title: title,
           content: content,
-          image_paths: image_paths,
+          image_paths: [],
           links: links
         )
       end

--- a/lib/powerpoint/presentation.rb
+++ b/lib/powerpoint/presentation.rb
@@ -202,6 +202,16 @@ module Powerpoint
       @slides << Powerpoint::Slide::FFTrendList.new(presentation: self, title: title, contents: contents, links: links, trend_list_start_num: trend_list_start_num)
     end
 
+    def add_ff_trend_summary_slide(title, content, image_path, link)
+      @slides << Powerpoint::Slide::FFTrendSummary.new(
+        presentation: self,
+        title: title,
+        content: content,
+        image_path: image_path,
+        link: link
+      )
+    end
+
     def init_files
       @dir = Dir.mktmpdir
       @extract_path = "#{@dir}/extract_#{Time.now.strftime("%Y-%m-%d-%H%M%S")}"

--- a/lib/powerpoint/slide/ff_trend_summary.rb
+++ b/lib/powerpoint/slide/ff_trend_summary.rb
@@ -1,0 +1,42 @@
+require 'zip/filesystem'
+require 'fileutils'
+require 'fastimage'
+require 'erb'
+require 'mimemagic'
+
+module Powerpoint
+    module Slide
+    class FFTrendSummary
+      include Powerpoint::Util
+
+      attr_reader :title, :content, :image_path, :link
+
+      def initialize(options={})
+        require_arguments [:presentation, :title, :content, :image_path, :link], options
+        options.each {|k, v| instance_variable_set("@#{k}", v)}
+        @image_name = File.basename(@image_path) if @image_path != nil && @image_path != ""
+      end
+
+      def file_type
+        [{ type: MimeMagic.by_magic(File.open(@image_path)).type, path: "/ppt/media/#{@image_name}" }]
+      end
+
+      def save(extract_path, index)
+        copy_media(extract_path, @image_path) if @image_path != nil && @image_name != ""
+        save_rel_xml(extract_path, index)
+        save_slide_xml(extract_path, index)
+      end
+
+      def save_rel_xml(extract_path, index)
+        render_view('ff_trend_summary_rel.xml.erb', "#{extract_path}/ppt/slides/_rels/slide#{index}.xml.rels")
+      end
+      private :save_rel_xml
+
+      def save_slide_xml(extract_path, index)
+        render_view('ff_trend_summary_slide.xml.erb', "#{extract_path}/ppt/slides/slide#{index}.xml")
+      end
+      private :save_slide_xml
+
+    end
+  end
+end

--- a/lib/powerpoint/util.rb
+++ b/lib/powerpoint/util.rb
@@ -73,7 +73,14 @@ module Powerpoint
       result.gsub!(/\s*<!--(.*?)-->\s*/m, '')
       result = remove_declaration(result)
       result = remove_newlines(result)
-      # result = remove_whitespace(result)
+      
+      # Add proper paragraph spacing
+      # Replace each paragraph start with one that includes proper spacing
+      # result = result.gsub(/<a:p>/, '<a:p><a:pPr><a:spcBef><a:spcPts val="0"/></a:spcBef><a:spcAft><a:spcPts val="1000"/></a:spcAft></a:pPr>')
+      
+      # Handle any existing paragraph properties
+      # result = result.gsub(/<a:p><a:pPr>/, '<a:p><a:pPr><a:spcBef><a:spcPts val="0"/></a:spcBef><a:spcAft><a:spcPts val="1000"/></a:spcAft>')
+      
       result
     end
 

--- a/lib/powerpoint/util.rb
+++ b/lib/powerpoint/util.rb
@@ -73,15 +73,6 @@ module Powerpoint
       result.gsub!(/\s*<!--(.*?)-->\s*/m, '')
       result = remove_declaration(result)
       result = remove_newlines(result)
-      
-      # Add proper paragraph spacing
-      # Replace each paragraph start with one that includes proper spacing
-      # result = result.gsub(/<a:p>/, '<a:p><a:pPr><a:spcBef><a:spcPts val="0"/></a:spcBef><a:spcAft><a:spcPts val="1000"/></a:spcAft></a:pPr>')
-      
-      # Handle any existing paragraph properties
-      # result = result.gsub(/<a:p><a:pPr>/, '<a:p><a:pPr><a:spcBef><a:spcPts val="0"/></a:spcBef><a:spcAft><a:spcPts val="1000"/></a:spcAft>')
-      
-      result
     end
 
     def ooxml_blank?(ooxml)

--- a/lib/powerpoint/util.rb
+++ b/lib/powerpoint/util.rb
@@ -72,7 +72,8 @@ module Powerpoint
       result = Htmltoooxml::Document.new().transform_doc_xml(source, false)
       result.gsub!(/\s*<!--(.*?)-->\s*/m, '')
       result = remove_declaration(result)
-      result = remove_whitespace(result)
+      result = remove_newlines(result)
+      # result = remove_whitespace(result)
       result
     end
 
@@ -99,6 +100,10 @@ module Powerpoint
 
     def remove_declaration(ooxml)
       ooxml.sub(/<\?xml (.*?)>/, '').gsub(/\s*xmlns:(\w+)="(.*?)\s*"/, '')
+    end
+
+    def remove_newlines(ooxml)
+      ooxml.gsub("\n","")
     end
   end
 end

--- a/lib/powerpoint/views/collision-2025/ff_heading_text_slide.xml.erb
+++ b/lib/powerpoint/views/collision-2025/ff_heading_text_slide.xml.erb
@@ -91,50 +91,6 @@
       </p:sp>
       <p:sp>
         <p:nvSpPr>
-          <p:cNvPr id="2" name="Slide Number Placeholder 5">
-            <a:extLst>
-              <a:ext uri="{FF2B5EF4-FFF2-40B4-BE49-F238E27FC236}">
-                <a16:creationId xmlns:a16="http://schemas.microsoft.com/office/drawing/2014/main"
-                  id="{0375CFC6-DC4A-6711-7F5A-5C75CF0F9B42}" />
-              </a:ext>
-            </a:extLst>
-          </p:cNvPr>
-          <p:cNvSpPr>
-            <a:spLocks noGrp="1" />
-          </p:cNvSpPr>
-          <p:nvPr>
-            <p:ph type="sldNum" sz="quarter" idx="10" />
-          </p:nvPr>
-        </p:nvSpPr>
-        <p:spPr>
-          <a:xfrm>
-            <a:off x="11389658" y="192438" />
-            <a:ext cx="508747" cy="153888" />
-          </a:xfrm>
-        </p:spPr>
-        <p:txBody>
-          <a:bodyPr />
-          <a:lstStyle>
-            <a:lvl1pPr>
-              <a:defRPr>
-                <a:solidFill>
-                  <a:schemeClr val="accent1" />
-                </a:solidFill>
-              </a:defRPr>
-            </a:lvl1pPr>
-          </a:lstStyle>
-          <a:p>
-            <a:fld id="{1A1A750F-FD42-4280-B238-1AD3A0FAB732}" type="slidenum">
-              <a:rPr lang="en-GB" smtClean="0" />
-              <a:pPr />
-              <a:t>2</a:t>
-            </a:fld>
-            <a:endParaRPr lang="en-GB" />
-          </a:p>
-        </p:txBody>
-      </p:sp>
-      <p:sp>
-        <p:nvSpPr>
           <p:cNvPr id="36" name="Title 35">
             <a:extLst>
               <a:ext uri="{FF2B5EF4-FFF2-40B4-BE49-F238E27FC236}">

--- a/lib/powerpoint/views/collision-2025/ff_three_row_text_slide.xml.erb
+++ b/lib/powerpoint/views/collision-2025/ff_three_row_text_slide.xml.erb
@@ -75,7 +75,7 @@
         <p:spPr>
           <a:xfrm>
             <a:off x="327212" y="790573" />
-            <a:ext cx="7590194" cy="512961" />
+            <a:ext cx="11569716" cy="512961" />
           </a:xfrm>
         </p:spPr>
         <p:txBody>

--- a/lib/powerpoint/views/collision-2025/ff_trend_intro_slide.xml.erb
+++ b/lib/powerpoint/views/collision-2025/ff_trend_intro_slide.xml.erb
@@ -85,31 +85,22 @@
           </a:prstGeom>
           <a:gradFill>
             <a:gsLst>
-              <a:gs pos="25990">
+              <a:gs pos="35000">
                 <a:srgbClr val="29005A">
-                  <a:alpha val="48000" />
+                  <a:alpha val="40000" />
                 </a:srgbClr>
               </a:gs>
-              <a:gs pos="78000">
-                <a:schemeClr val="tx2" />
-              </a:gs>
-              <a:gs pos="50000">
-                <a:schemeClr val="tx2">
-                  <a:alpha val="89069" />
-                </a:schemeClr>
-              </a:gs>
               <a:gs pos="0">
-                <a:schemeClr val="tx2">
-                  <a:alpha val="60207" />
-                </a:schemeClr>
+                <a:schemeClr val="tx2" />
               </a:gs>
               <a:gs pos="100000">
                 <a:schemeClr val="accent3">
                   <a:lumMod val="10000" />
+                  <a:alpha val="0" />
                 </a:schemeClr>
               </a:gs>
             </a:gsLst>
-            <a:lin ang="10800000" scaled="0" />
+            <a:lin ang="0" scaled="0" />
           </a:gradFill>
           <a:ln>
             <a:noFill />

--- a/lib/powerpoint/views/collision-2025/ff_trend_intro_slide.xml.erb
+++ b/lib/powerpoint/views/collision-2025/ff_trend_intro_slide.xml.erb
@@ -224,7 +224,7 @@
         </p:spPr>
         <p:txBody>
           <a:bodyPr vert="horz" lIns="0" tIns="0" rIns="0" bIns="0" rtlCol="0">
-            <a:normAutofit />
+            <a:noAutofit />
           </a:bodyPr>
           <a:lstStyle />
           <a:p>

--- a/lib/powerpoint/views/collision-2025/ff_trend_intro_slide.xml.erb
+++ b/lib/powerpoint/views/collision-2025/ff_trend_intro_slide.xml.erb
@@ -219,7 +219,7 @@
         <p:spPr>
           <a:xfrm>
             <a:off x="327212" y="3944938" />
-            <a:ext cx="5337864" cy="688022" />
+            <a:ext cx="5337864" cy="964992" />
           </a:xfrm>
         </p:spPr>
         <p:txBody>

--- a/lib/powerpoint/views/collision-2025/ff_trend_intro_slide.xml.erb
+++ b/lib/powerpoint/views/collision-2025/ff_trend_intro_slide.xml.erb
@@ -188,7 +188,7 @@
         <p:txBody>
           <a:bodyPr vert="horz" lIns="0" tIns="0" rIns="0" bIns="0" rtlCol="0" anchor="b"
             anchorCtr="0">
-            <a:normAutofit fontScale="90000" />
+            <a:normAutofit />
           </a:bodyPr>
           <a:lstStyle />
           <a:p>

--- a/lib/powerpoint/views/collision-2025/ff_trend_intro_slide.xml.erb
+++ b/lib/powerpoint/views/collision-2025/ff_trend_intro_slide.xml.erb
@@ -398,48 +398,6 @@
           </a:prstGeom>
         </p:spPr>
       </p:pic>
-      <p:cxnSp>
-        <p:nvCxnSpPr>
-          <p:cNvPr id="10" name="Straight Connector 9">
-            <a:extLst>
-              <a:ext uri="{FF2B5EF4-FFF2-40B4-BE49-F238E27FC236}">
-                <a16:creationId xmlns:a16="http://schemas.microsoft.com/office/drawing/2014/main"
-                  id="{22EAA244-4CEC-AB39-F141-BBF9FE355ADC}" />
-              </a:ext>
-            </a:extLst>
-          </p:cNvPr>
-          <p:cNvCxnSpPr />
-          <p:nvPr />
-        </p:nvCxnSpPr>
-        <p:spPr>
-          <a:xfrm>
-            <a:off x="2286000" y="198120" />
-            <a:ext cx="0" cy="495300" />
-          </a:xfrm>
-          <a:prstGeom prst="line">
-            <a:avLst />
-          </a:prstGeom>
-          <a:ln w="6350">
-            <a:solidFill>
-              <a:schemeClr val="bg1" />
-            </a:solidFill>
-          </a:ln>
-        </p:spPr>
-        <p:style>
-          <a:lnRef idx="2">
-            <a:schemeClr val="accent1" />
-          </a:lnRef>
-          <a:fillRef idx="0">
-            <a:schemeClr val="accent1" />
-          </a:fillRef>
-          <a:effectRef idx="1">
-            <a:schemeClr val="accent1" />
-          </a:effectRef>
-          <a:fontRef idx="minor">
-            <a:schemeClr val="tx1" />
-          </a:fontRef>
-        </p:style>
-      </p:cxnSp>
       <% if trend_number != nil %>
 			<p:sp>
 				<p:nvSpPr>

--- a/lib/powerpoint/views/collision-2025/ff_trend_summary_rel.xml.erb
+++ b/lib/powerpoint/views/collision-2025/ff_trend_summary_rel.xml.erb
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId3" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/image" Target="../media/<%= @image_name %>" />
+  <Relationship Id="rId2"
+    Target="<%= @link %>"
+    Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/hyperlink"
+    TargetMode="External" />
+  <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/slideLayout" Target="../slideLayouts/slideLayout10.xml"/>
+</Relationships>

--- a/lib/powerpoint/views/collision-2025/ff_trend_summary_slide.xml.erb
+++ b/lib/powerpoint/views/collision-2025/ff_trend_summary_slide.xml.erb
@@ -1,0 +1,377 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<p:sld xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main"
+  xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships"
+  xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main">
+  <p:cSld>
+    <p:bg>
+      <p:bgPr>
+        <a:solidFill>
+          <a:schemeClr val="bg2"/>
+        </a:solidFill>
+        <a:effectLst/>
+      </p:bgPr>
+    </p:bg>
+    <p:spTree>
+      <p:nvGrpSpPr>
+        <p:cNvPr id="1" name=""/>
+        <p:cNvGrpSpPr/>
+        <p:nvPr/>
+      </p:nvGrpSpPr>
+      <p:grpSpPr>
+        <a:xfrm>
+          <a:off x="0" y="0"/>
+          <a:ext cx="0" cy="0"/>
+          <a:chOff x="0" y="0"/>
+          <a:chExt cx="0" cy="0"/>
+        </a:xfrm>
+      </p:grpSpPr>
+      <p:sp>
+        <p:nvSpPr>
+          <p:cNvPr id="4" name="Text Placeholder 3">
+            <a:extLst>
+              <a:ext uri="{FF2B5EF4-FFF2-40B4-BE49-F238E27FC236}">
+                <a16:creationId xmlns:a16="http://schemas.microsoft.com/office/drawing/2014/main" id="{555C461B-12D8-D490-41EE-946F6DB187B4}"/>
+              </a:ext>
+            </a:extLst>
+          </p:cNvPr>
+          <p:cNvSpPr>
+            <a:spLocks noGrp="1"/>
+          </p:cNvSpPr>
+          <p:nvPr>
+            <p:ph type="body" idx="4294967295"/>
+          </p:nvPr>
+        </p:nvSpPr>
+        <p:spPr>
+          <a:xfrm>
+            <a:off x="6499413" y="3883948"/>
+            <a:ext cx="4749609" cy="215444"/>
+          </a:xfrm>
+        </p:spPr>
+        <p:txBody>
+          <a:bodyPr/>
+          <a:lstStyle/>
+          <a:p>
+            <a:r>
+              <a:rPr lang="en-GB" sz="1400">
+                <a:hlinkClick r:id="rId2"/>
+              </a:rPr>
+              <a:t>View the full trend</a:t>
+            </a:r>
+            <a:endParaRPr lang="en-GB" sz="1400"/>
+          </a:p>
+        </p:txBody>
+      </p:sp>
+      <p:sp>
+        <p:nvSpPr>
+          <p:cNvPr id="6" name="Text Placeholder 5">
+            <a:extLst>
+              <a:ext uri="{FF2B5EF4-FFF2-40B4-BE49-F238E27FC236}">
+                <a16:creationId xmlns:a16="http://schemas.microsoft.com/office/drawing/2014/main" id="{B758DE66-8189-5459-7589-14E1B7076665}"/>
+              </a:ext>
+            </a:extLst>
+          </p:cNvPr>
+          <p:cNvSpPr>
+            <a:spLocks noGrp="1"/>
+          </p:cNvSpPr>
+          <p:nvPr>
+            <p:ph type="body" idx="4294967295"/>
+          </p:nvPr>
+        </p:nvSpPr>
+        <p:spPr>
+          <a:xfrm>
+            <a:off x="6499411" y="1785119"/>
+            <a:ext cx="4749609" cy="984885"/>
+          </a:xfrm>
+        </p:spPr>
+        <p:txBody>
+          <a:bodyPr/>
+          <a:lstStyle/>
+          <a:p>
+            <a:r>
+              <a:rPr lang="en-GB" sz="3200"/>
+              <a:t><%= @title ? @title.strip.encode(:xml => :text) : "\u00A0" %></a:t>
+            </a:r>
+          </a:p>
+          <a:p>
+            <a:endParaRPr lang="en-GB" sz="3200"/>
+          </a:p>
+        </p:txBody>
+      </p:sp>
+      <p:sp>
+        <p:nvSpPr>
+          <p:cNvPr id="7" name="Text Placeholder 6">
+            <a:extLst>
+              <a:ext uri="{FF2B5EF4-FFF2-40B4-BE49-F238E27FC236}">
+                <a16:creationId xmlns:a16="http://schemas.microsoft.com/office/drawing/2014/main" id="{AED99E54-FA63-D43B-DC63-FBEABE3715A3}"/>
+              </a:ext>
+            </a:extLst>
+          </p:cNvPr>
+          <p:cNvSpPr>
+            <a:spLocks noGrp="1"/>
+          </p:cNvSpPr>
+          <p:nvPr>
+            <p:ph type="body" idx="4294967295"/>
+          </p:nvPr>
+        </p:nvSpPr>
+        <p:spPr>
+          <a:xfrm>
+            <a:off x="6499410" y="2946168"/>
+            <a:ext cx="4749613" cy="903581"/>
+          </a:xfrm>
+        </p:spPr>
+        <p:txBody>
+          <a:bodyPr/>
+          <a:lstStyle/>
+            <%= content || html_to_ooxml('&nbsp;') %>
+        </p:txBody>
+      </p:sp>
+      <p:pic>
+        <p:nvPicPr>
+          <p:cNvPr id="17" name="Picture 1" descr="Picture 1">
+            <a:extLst>
+              <a:ext uri="{FF2B5EF4-FFF2-40B4-BE49-F238E27FC236}">
+                <a16:creationId xmlns:a16="http://schemas.microsoft.com/office/drawing/2014/main" id="{47187E7E-8FE6-AD77-3AB6-FAE8BAD6BFBD}"/>
+              </a:ext>
+            </a:extLst>
+          </p:cNvPr>
+          <p:cNvPicPr>
+            <a:picLocks noGrp="1" noChangeAspect="1" noChangeArrowheads="1"/>
+          </p:cNvPicPr>
+          <p:nvPr>
+            <p:ph type="pic" sz="quarter" idx="47"/>
+          </p:nvPr>
+        </p:nvPicPr>
+        <p:blipFill>
+          <a:blip r:embed="rId3" cstate="print"/>
+          <a:srcRect t="12500" b="12500"/>
+          <a:stretch>
+            <a:fillRect/>
+          </a:stretch>
+        </p:blipFill>
+        <p:spPr bwMode="auto">
+          <a:xfrm>
+              <%
+                min_x = pt_to_pixle(1)
+                min_y = pt_to_pixle(780756)
+                max_width = pt_to_pixle(6096000)
+                max_height = pt_to_pixle(5769356)
+
+                image_position_data = size_and_position_image(
+                  @image_path,
+                  x: min_x,
+                  y: min_y,
+                  max_height: max_height,
+                  max_width: max_width
+                )
+              %>
+              <a:off x="<%= pixle_to_pt(image_position_data.x) %>" y="<%= pixle_to_pt(image_position_data.y) %>"/>
+              <a:ext cx="<%= pixle_to_pt(image_position_data.width) %>" cy="<%= pixle_to_pt(image_position_data.height) %>"/>
+            </a:xfrm>
+          <a:prstGeom prst="rect">
+            <a:avLst/>
+          </a:prstGeom>
+          <a:noFill/>
+        </p:spPr>
+      </p:pic>
+      <p:sp>
+        <p:nvSpPr>
+          <p:cNvPr id="2" name="Slide Number Placeholder 5">
+            <a:extLst>
+              <a:ext uri="{FF2B5EF4-FFF2-40B4-BE49-F238E27FC236}">
+                <a16:creationId xmlns:a16="http://schemas.microsoft.com/office/drawing/2014/main" id="{3F2CB3F6-5C35-D1A3-C441-813344EBBAF3}"/>
+              </a:ext>
+            </a:extLst>
+          </p:cNvPr>
+          <p:cNvSpPr txBox="1">
+            <a:spLocks/>
+          </p:cNvSpPr>
+          <p:nvPr/>
+        </p:nvSpPr>
+        <p:spPr>
+          <a:xfrm>
+            <a:off x="11389658" y="192438"/>
+            <a:ext cx="508747" cy="153888"/>
+          </a:xfrm>
+          <a:prstGeom prst="rect">
+            <a:avLst/>
+          </a:prstGeom>
+        </p:spPr>
+        <p:txBody>
+          <a:bodyPr/>
+          <a:lstStyle>
+            <a:defPPr>
+              <a:defRPr lang="en-US"/>
+            </a:defPPr>
+            <a:lvl1pPr marL="0" algn="l" defTabSz="914400" rtl="0" eaLnBrk="1" latinLnBrk="0" hangingPunct="1">
+              <a:defRPr sz="1800" kern="1200">
+                <a:solidFill>
+                  <a:schemeClr val="accent1"/>
+                </a:solidFill>
+                <a:latin typeface="+mn-lt"/>
+                <a:ea typeface="+mn-ea"/>
+                <a:cs typeface="+mn-cs"/>
+              </a:defRPr>
+            </a:lvl1pPr>
+            <a:lvl2pPr marL="457200" algn="l" defTabSz="914400" rtl="0" eaLnBrk="1" latinLnBrk="0" hangingPunct="1">
+              <a:defRPr sz="1800" kern="1200">
+                <a:solidFill>
+                  <a:schemeClr val="tx1"/>
+                </a:solidFill>
+                <a:latin typeface="+mn-lt"/>
+                <a:ea typeface="+mn-ea"/>
+                <a:cs typeface="+mn-cs"/>
+              </a:defRPr>
+            </a:lvl2pPr>
+            <a:lvl3pPr marL="914400" algn="l" defTabSz="914400" rtl="0" eaLnBrk="1" latinLnBrk="0" hangingPunct="1">
+              <a:defRPr sz="1800" kern="1200">
+                <a:solidFill>
+                  <a:schemeClr val="tx1"/>
+                </a:solidFill>
+                <a:latin typeface="+mn-lt"/>
+                <a:ea typeface="+mn-ea"/>
+                <a:cs typeface="+mn-cs"/>
+              </a:defRPr>
+            </a:lvl3pPr>
+            <a:lvl4pPr marL="1371600" algn="l" defTabSz="914400" rtl="0" eaLnBrk="1" latinLnBrk="0" hangingPunct="1">
+              <a:defRPr sz="1800" kern="1200">
+                <a:solidFill>
+                  <a:schemeClr val="tx1"/>
+                </a:solidFill>
+                <a:latin typeface="+mn-lt"/>
+                <a:ea typeface="+mn-ea"/>
+                <a:cs typeface="+mn-cs"/>
+              </a:defRPr>
+            </a:lvl4pPr>
+            <a:lvl5pPr marL="1828800" algn="l" defTabSz="914400" rtl="0" eaLnBrk="1" latinLnBrk="0" hangingPunct="1">
+              <a:defRPr sz="1800" kern="1200">
+                <a:solidFill>
+                  <a:schemeClr val="tx1"/>
+                </a:solidFill>
+                <a:latin typeface="+mn-lt"/>
+                <a:ea typeface="+mn-ea"/>
+                <a:cs typeface="+mn-cs"/>
+              </a:defRPr>
+            </a:lvl5pPr>
+            <a:lvl6pPr marL="2286000" algn="l" defTabSz="914400" rtl="0" eaLnBrk="1" latinLnBrk="0" hangingPunct="1">
+              <a:defRPr sz="1800" kern="1200">
+                <a:solidFill>
+                  <a:schemeClr val="tx1"/>
+                </a:solidFill>
+                <a:latin typeface="+mn-lt"/>
+                <a:ea typeface="+mn-ea"/>
+                <a:cs typeface="+mn-cs"/>
+              </a:defRPr>
+            </a:lvl6pPr>
+            <a:lvl7pPr marL="2743200" algn="l" defTabSz="914400" rtl="0" eaLnBrk="1" latinLnBrk="0" hangingPunct="1">
+              <a:defRPr sz="1800" kern="1200">
+                <a:solidFill>
+                  <a:schemeClr val="tx1"/>
+                </a:solidFill>
+                <a:latin typeface="+mn-lt"/>
+                <a:ea typeface="+mn-ea"/>
+                <a:cs typeface="+mn-cs"/>
+              </a:defRPr>
+            </a:lvl7pPr>
+            <a:lvl8pPr marL="3200400" algn="l" defTabSz="914400" rtl="0" eaLnBrk="1" latinLnBrk="0" hangingPunct="1">
+              <a:defRPr sz="1800" kern="1200">
+                <a:solidFill>
+                  <a:schemeClr val="tx1"/>
+                </a:solidFill>
+                <a:latin typeface="+mn-lt"/>
+                <a:ea typeface="+mn-ea"/>
+                <a:cs typeface="+mn-cs"/>
+              </a:defRPr>
+            </a:lvl8pPr>
+            <a:lvl9pPr marL="3657600" algn="l" defTabSz="914400" rtl="0" eaLnBrk="1" latinLnBrk="0" hangingPunct="1">
+              <a:defRPr sz="1800" kern="1200">
+                <a:solidFill>
+                  <a:schemeClr val="tx1"/>
+                </a:solidFill>
+                <a:latin typeface="+mn-lt"/>
+                <a:ea typeface="+mn-ea"/>
+                <a:cs typeface="+mn-cs"/>
+              </a:defRPr>
+            </a:lvl9pPr>
+          </a:lstStyle>
+          <a:p>
+            <a:pPr marL="0" marR="0" lvl="0" indent="0" algn="r" defTabSz="914400" rtl="0" eaLnBrk="1" fontAlgn="auto" latinLnBrk="0" hangingPunct="1">
+              <a:lnSpc>
+                <a:spcPct val="100000"/>
+              </a:lnSpc>
+              <a:spcBef>
+                <a:spcPts val="0"/>
+              </a:spcBef>
+              <a:spcAft>
+                <a:spcPts val="0"/>
+              </a:spcAft>
+              <a:buClrTx/>
+              <a:buSzTx/>
+              <a:buFontTx/>
+              <a:buNone/>
+              <a:tabLst/>
+              <a:defRPr/>
+            </a:pPr>
+            <a:r>
+              <a:rPr kumimoji="0" lang="en-GB" sz="1000" b="0" i="0" u="none" strike="noStrike" kern="1200" cap="none" spc="0" normalizeH="0" baseline="0" noProof="0">
+                <a:ln>
+                  <a:noFill/>
+                </a:ln>
+                <a:solidFill>
+                  <a:srgbClr val="5E00E6"/>
+                </a:solidFill>
+                <a:effectLst/>
+                <a:uLnTx/>
+                <a:uFillTx/>
+                <a:latin typeface="Arial"/>
+                <a:ea typeface="+mn-ea"/>
+                <a:cs typeface="+mn-cs"/>
+              </a:rPr>
+              <a:t>9</a:t>
+            </a:r>
+          </a:p>
+        </p:txBody>
+      </p:sp>
+      <p:sp>
+        <p:nvSpPr>
+          <p:cNvPr id="15" name="Title 7">
+            <a:extLst>
+              <a:ext uri="{FF2B5EF4-FFF2-40B4-BE49-F238E27FC236}">
+                <a16:creationId xmlns:a16="http://schemas.microsoft.com/office/drawing/2014/main" id="{6165BE84-62F9-1C6F-2075-FA83C77344D0}"/>
+              </a:ext>
+            </a:extLst>
+          </p:cNvPr>
+          <p:cNvSpPr>
+            <a:spLocks noGrp="1"/>
+          </p:cNvSpPr>
+          <p:nvPr>
+            <p:ph type="title"/>
+          </p:nvPr>
+        </p:nvSpPr>
+        <p:spPr>
+          <a:xfrm>
+            <a:off x="327212" y="790573"/>
+            <a:ext cx="11537580" cy="512961"/>
+          </a:xfrm>
+        </p:spPr>
+        <p:txBody>
+          <a:bodyPr/>
+          <a:lstStyle/>
+          <a:p>
+            <a:r>
+              <a:rPr lang="en-GB"/>
+              <a:t>Trends to activate</a:t>
+            </a:r>
+          </a:p>
+        </p:txBody>
+      </p:sp>
+    </p:spTree>
+    <p:extLst>
+      <p:ext uri="{BB962C8B-B14F-4D97-AF65-F5344CB8AC3E}">
+        <p14:creationId xmlns:p14="http://schemas.microsoft.com/office/powerpoint/2010/main" val="2205178955"/>
+      </p:ext>
+    </p:extLst>
+  </p:cSld>
+  <p:clrMapOvr>
+    <a:masterClrMapping/>
+  </p:clrMapOvr>
+</p:sld>

--- a/lib/powerpoint/views/collision-2025/ff_two_column_chart_slide.xml.erb
+++ b/lib/powerpoint/views/collision-2025/ff_two_column_chart_slide.xml.erb
@@ -475,8 +475,17 @@
         </p:blipFill>
         <p:spPr>
           <a:xfrm>
-            <a:off x="6467475" y="3581400" />
-            <a:ext cx="5219700" cy="2849563" />
+            <%
+              image_position_data = size_and_position_image(
+                images[1].last,
+                x: pt_to_pixle(6467475),
+                y: pt_to_pixle(3581400),
+                max_height: pt_to_pixle(2849563),
+                max_width: pt_to_pixle(5219700),
+              )
+            %>
+            <a:off x="<%= pixle_to_pt(image_position_data.x) %>" y="<%= pixle_to_pt(image_position_data.y) %>" />
+            <a:ext cx="<%= pixle_to_pt(image_position_data.width) %>" cy="<%= pixle_to_pt(image_position_data.height) %>" />
           </a:xfrm>
           <a:prstGeom prst="rect">
             <a:avLst />
@@ -510,8 +519,17 @@
         </p:blipFill>
         <p:spPr>
           <a:xfrm>
-            <a:off x="539750" y="3581400" />
-            <a:ext cx="5219700" cy="2849563" />
+            <%
+              image_position_data = size_and_position_image(
+                images[1].last,
+                x: pt_to_pixle(539750),
+                y: pt_to_pixle(3581400),
+                max_height: pt_to_pixle(2849563),
+                max_width: pt_to_pixle(5219700),
+              )
+            %>
+            <a:off x="<%= pixle_to_pt(image_position_data.x) %>" y="<%= pixle_to_pt(image_position_data.y) %>" />
+            <a:ext cx="<%= pixle_to_pt(image_position_data.width) %>" cy="<%= pixle_to_pt(image_position_data.height) %>" />
           </a:xfrm>
           <a:prstGeom prst="rect">
             <a:avLst />

--- a/lib/powerpoint/views/collision-2025/ff_two_column_chart_slide.xml.erb
+++ b/lib/powerpoint/views/collision-2025/ff_two_column_chart_slide.xml.erb
@@ -477,7 +477,7 @@
           <a:xfrm>
             <%
               image_position_data = size_and_position_image(
-                images[1].last,
+                images[0].last,
                 x: pt_to_pixle(6467475),
                 y: pt_to_pixle(3581400),
                 max_height: pt_to_pixle(2849563),

--- a/spec/test_spec.rb
+++ b/spec/test_spec.rb
@@ -14,7 +14,7 @@ describe 'Powerpoint parsing a sample PPTX file' do
     @three_col_content = {"global"=>{"title"=>"Global", "dataType"=>"fieldset", "items"=>{"downloadableInput"=>{"title"=>"Downloadable: ", "dataType"=>"checkBox", "disabled"=>true, "items"=>["as PowerPoint", "as PDF"], "value"=>["as PowerPoint", "as PDF"]}}}, "headingInput"=>{"dataType"=>"text", "title"=>"Heading: ", "value"=>"Lorem Ipsum Dolor Sit Amet"}, "column1"=>{"dataType"=>"fieldset", "items"=>{"headingInput"=>{"dataType"=>"text", "title"=>"Heading: ", "value"=>"Lorem Ipsum Dolor Consec"}, "textInput"=>{"dataType"=>"richText", "title"=>"Text: ", "value"=>"<p><a href=\"http://www.spicerack.co.uk/\">Foo bar bob link</a>Sum expectantes. Ego hodie expectantes. Expectantes, et misit unum de pueris Gus interficere. Et suus vos. Nescio quis, qui est bonus usus liberi ad Isai? Qui nosti ... Quis dimisit filios ad necem ... hmm? Gus! Est, ante me factus singulis decem gradibus. Et nunc ad aliud opus mihi tandem tollendum est puer ille consensus et nunc fugit. Ipse suus obtinuit eam. Non solum autem illa, sed te tractantur in se trahens felis. </p>"}}, "disabled"=>false, "title"=>"Column 1"}, "column2"=>{"dataType"=>"fieldset", "items"=>{"headingInput"=>{"dataType"=>"text", "title"=>"Heading: ", "value"=>"Consectetur Adipiscing"}, "textInput"=>{"dataType"=>"richText", "title"=>"Text: ", "value"=>"<p>Sum expectantes. Ego hodie expectantes. Expectantes, et misit unum de pueris Gus interficere. Et suus vos. Nescio quis, qui est bonus usus liberi ad Isai?</p><p>Qui nosti ... Quis dimisit filios ad necem ... hmm? Gus! Est, ante me factus singulis decem gradibus.</p><p>Et nunc ad aliud opus mihi tandem tollendum est puer ille consensus et nunc fugit. Ipse suus obtinuit eam. Non solum autem illa, sed te tractantur in se trahens felis. </p>"}}, "title"=>"Column 2"}, "column3"=>{"dataType"=>"fieldset", "items"=>{"headingInput"=>{"dataType"=>"text", "title"=>"Heading: ", "value"=>"Pariatur Consectetur"}, "textInput"=>{"dataType"=>"richText", "title"=>"Text: ", "value"=>"<p>Sum expectantes. Ego hodie expectantes. Expectantes, et misit unum de pueris Gus interficere. Et suus vos. Nescio quis, qui est bonus usus liberi ad Isai? Qui nosti ... Quis dimisit filios ad necem ... hmm? Gus! </p><p>Est, ante me factus singulis decem gradibus.</p>"}}, "title"=>"Column 3"}}
     @three_col_content = {"global"=>{"title"=>"Global", "dataType"=>"fieldset", "items"=>{"subPageNavigationMenu"=>{"dataType"=>"subPageNavigationMenu"}, "downloadableInput"=>{"title"=>"Downloadable: ", "dataType"=>"checkBox", "disabled"=>true, "items"=>["as PowerPoint", "as PDF"], "value"=>["as PowerPoint", "as PDF"]}}}, "headingInput"=>{"dataType"=>"text", "title"=>"Heading: ", "value"=>"Lorem Ipsum Dolor Sit Amet"}, "column1"=>{"dataType"=>"fieldset", "items"=>{"headingInput"=>{"dataType"=>"text", "title"=>"Heading: ", "value"=>"Lorem Ipsum Dolor Consec"}, "textInput"=>{"dataType"=>"richText", "title"=>"Text: ", "value"=>"<p>\n    Testing <a href=\"https://stylefoundry.atlassian.net/\">blah blah</a>\n</p>"}}, "disabled"=>false, "title"=>"Column 1"}, "column2"=>{"dataType"=>"fieldset", "items"=>{"headingInput"=>{"dataType"=>"text", "title"=>"Heading: ", "value"=>"Consectetur Adipiscing"}, "textInput"=>{"dataType"=>"richText", "title"=>"Text: ", "value"=>"<p>\n    test\n</p>"}}, "title"=>"Column 2"}, "column3"=>{"dataType"=>"fieldset", "items"=>{"headingInput"=>{"dataType"=>"text", "title"=>"Heading: ", "value"=>"Pariatur Consectetur"}, "textInput"=>{"dataType"=>"richText", "title"=>"Text: ", "value"=>"<p>\n    test\n</p>"}}, "title"=>"Column 3"}}
     @html = '
-      <h1>A very long title to test breaking over two lines works correctly</h1><p>
+<h1>A very long title to test breaking over two lines works correctly</h1><p>
 <strong>Bedtime</strong>, and <i>evening</i> time in general, is being re-defined. For a significant number, the hours before sleep can be penetrated by a kind of light work; it is now so easy to curl round a laptop or a tablet and drop your boss an email, while scanning the latest news, while streaming on-demand movies, while online shopping for your mother’s birthday present, and so on.
 </p>
 <p>
@@ -24,7 +24,7 @@ describe 'Powerpoint parsing a sample PPTX file' do
 Work-life <a href="http://www.spicerack.co.uk">balance</a> is redrawn under wider horizons. This is not just a story of more flexible working hours but a story of work encroaching into those times and places formerly reserved for rest: night time, bedrooms, even holidays. To many millennials, work-life balance is in revolution.
 </p>
 <p>
-More, online media and retail are accessed differently in these arenas. Remote technology for both work and socialising means that consumers are engaging with their devices, and their fellow human beings, in a totally new way.
+More, online media and retail are <b>accessed</b> <i>differently</i> in these arenas. Remote technology for both work and socialising means that consumers are engaging with their devices, and their fellow human beings, in a totally new way.
 </p>
 <p>
 Work-life balance is redrawn under wider horizons. This is not just a story of more flexible working hours but a story of work encroaching into those times and places formerly reserved for rest: night time, bedrooms, even holidays. To many millennials, work-life balance is in revolution.
@@ -76,15 +76,21 @@ Work-life balance is redrawn under wider horizons. This is not just a story of m
     # @deck.add_ff_trend_intro_slide 'Abcdefghijklmnopqrstuvwxyz12345678910112', 'Contactless credit/debit cards, NFC- and web-enabled phones and digital wallets.', "samples/images/white.jpeg", '2'
     
     @deck.add_ff_heading_text_slide @header.inner_html ,html_to_ooxml(@final.to_s), @image_paths, links
+    
     # # #
     # # # # loop through total content remove 1st three and then work out how many slides needed based on 21 content items per slide
+    
     @deck.add_ff_trend_list_slide "test title", @contents, @content_links
+    
     # # #
     # @deck.add_ff_heading_text_slide @header.inner_html, html_to_ooxml(@bullet_html), @image_paths, links
     # # @deck.add_ff_three_row_text_slide 'What to do', @three_col_content, three_col_links
+    
     @deck.add_ff_what_next_slide 'What will happen next', @what_content
     @deck.add_ff_what_next_slide 'What will happen next 2', @what_missing_content
-    @deck.add_ff_sector_impact_slide @sector_content.first[1]['title'], @sector_content.first[1]['items'].first[1]['value'], sector_image_path, sector_impact_links
+    
+    # @deck.add_ff_sector_impact_slide @sector_content.first[1]['title'], @sector_content.first[1]['items'].first[1]['value'], sector_image_path, sector_impact_links
+
     @deck.add_ff_associated_content_slide 'Sample Asscociated Content Item', 'Test Associated Content Subtitle', 'samples/images/image5.jpeg', {}, 'sample.pptx'
     @deck.add_ff_text_left_chart_right_slide @header.inner_html ,html_to_ooxml(@final.to_s), "Which of these websites/apps have you used in the past month? TikTok(Douyin)", "subtitle", "samples/images/image5.jpeg", links 
     @deck.add_ff_text_right_chart_left_slide @header.inner_html ,html_to_ooxml(@final.to_s), "Which of these websites/apps have you used in the past month? TikTok(Douyin)", "subtitle", "samples/images/image5.jpeg", links 
@@ -92,7 +98,8 @@ Work-life balance is redrawn under wider horizons. This is not just a story of m
     @deck.add_ff_text_left_image_right_slide @header.inner_html ,html_to_ooxml(@final.to_s), "samples/images/image5.jpeg", links 
     @deck.add_ff_two_column_chart_slide @header.inner_html ,html_to_ooxml(@final.to_s), ["Which of these websites/apps have you used in the past month? TikTok(Douyin1)", "Which of these websites/apps have you used in the past month? TikTok(Douyin2)"], ["subtitle", "subtitle"], ["samples/images/image1.png", "samples/images/image5.jpeg"], links 
     @deck.add_ff_two_column_text_slide 'Test title', @header.inner_html, @header.inner_html, html_to_ooxml(@final.to_s), html_to_ooxml(@final.to_s), links
-    ##
+    @deck.add_ff_trend_summary_slide "Test Trend" ,html_to_ooxml("<p>Some test trend content that describes the trend in an sumarrised way."), "samples/images/image5.jpeg", links[0]
+    # ##
     # These are the embeded prenstatoins I have taken a selection of the ones that have tags, drawiings, charts etc
     #
     #  Loop through each and add the masters and layouts to the main output presentation
@@ -100,6 +107,7 @@ Work-life balance is redrawn under wider horizons. This is not just a story of m
     ##
     embed_decks = ["samples/pptx/new-chart.pptx","samples/pptx/35848.pptx","samples/pptx/trend-intensity.pptx"]
     # comment out this loop for a single slide test
+    # embed_decks = []
     embed_decks.each do |deck_path|
       @embed_deck = Powerpoint::ReadPresentation.new deck_path
     

--- a/templates/collision-2025-template/ppt/slideLayouts/slideLayout1.xml
+++ b/templates/collision-2025-template/ppt/slideLayouts/slideLayout1.xml
@@ -229,7 +229,7 @@
         </p:spPr>
         <p:txBody>
           <a:bodyPr>
-            <a:normAutofit />
+            <a:noAutofit />
           </a:bodyPr>
           <a:lstStyle>
             <a:lvl1pPr marL="0" indent="0" algn="l">

--- a/templates/collision-2025-template/ppt/slideLayouts/slideLayout1.xml
+++ b/templates/collision-2025-template/ppt/slideLayouts/slideLayout1.xml
@@ -1,2 +1,475 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<p:sldLayout xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships" xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main" preserve="1" userDrawn="1"><p:cSld name="Cover slide"><p:spTree><p:nvGrpSpPr><p:cNvPr id="1" name=""/><p:cNvGrpSpPr/><p:nvPr/></p:nvGrpSpPr><p:grpSpPr><a:xfrm><a:off x="0" y="0"/><a:ext cx="0" cy="0"/><a:chOff x="0" y="0"/><a:chExt cx="0" cy="0"/></a:xfrm></p:grpSpPr><p:sp><p:nvSpPr><p:cNvPr id="5" name="Picture Placeholder 4"><a:extLst><a:ext uri="{FF2B5EF4-FFF2-40B4-BE49-F238E27FC236}"><a16:creationId xmlns:a16="http://schemas.microsoft.com/office/drawing/2014/main" id="{C21B7C50-4A8F-0D4C-20DA-5E2A38CCF56B}"/></a:ext></a:extLst></p:cNvPr><p:cNvSpPr><a:spLocks noGrp="1"/></p:cNvSpPr><p:nvPr><p:ph type="pic" sz="quarter" idx="11"/></p:nvPr></p:nvSpPr><p:spPr><a:xfrm><a:off x="0" y="0"/><a:ext cx="12192000" cy="6858000"/></a:xfrm></p:spPr><p:txBody><a:bodyPr/><a:lstStyle/><a:p><a:endParaRPr lang="en-GB"/></a:p></p:txBody></p:sp><p:sp><p:nvSpPr><p:cNvPr id="4" name="Rectangle 3"><a:extLst><a:ext uri="{FF2B5EF4-FFF2-40B4-BE49-F238E27FC236}"><a16:creationId xmlns:a16="http://schemas.microsoft.com/office/drawing/2014/main" id="{D1169294-B756-930B-63EB-DA74F80322B7}"/></a:ext></a:extLst></p:cNvPr><p:cNvSpPr/><p:nvPr userDrawn="1"/></p:nvSpPr><p:spPr><a:xfrm flipH="1"><a:off x="0" y="0"/><a:ext cx="12192000" cy="6858000"/></a:xfrm><a:prstGeom prst="rect"><a:avLst/></a:prstGeom><a:gradFill><a:gsLst><a:gs pos="25990"><a:srgbClr val="29005A"><a:alpha val="48000"/></a:srgbClr></a:gs><a:gs pos="78000"><a:schemeClr val="tx2"/></a:gs><a:gs pos="50000"><a:schemeClr val="tx2"><a:alpha val="89069"/></a:schemeClr></a:gs><a:gs pos="0"><a:schemeClr val="tx2"><a:alpha val="60207"/></a:schemeClr></a:gs><a:gs pos="100000"><a:schemeClr val="accent3"><a:lumMod val="10000"/></a:schemeClr></a:gs></a:gsLst><a:lin ang="0" scaled="0"/></a:gradFill><a:ln><a:noFill/></a:ln></p:spPr><p:style><a:lnRef idx="2"><a:schemeClr val="accent1"><a:shade val="15000"/></a:schemeClr></a:lnRef><a:fillRef idx="1"><a:schemeClr val="accent1"/></a:fillRef><a:effectRef idx="0"><a:schemeClr val="accent1"/></a:effectRef><a:fontRef idx="minor"><a:schemeClr val="lt1"/></a:fontRef></p:style><p:txBody><a:bodyPr rtlCol="0" anchor="ctr"/><a:lstStyle/><a:p><a:pPr marL="0" marR="0" lvl="0" indent="0" algn="ctr" defTabSz="914400" rtl="0" eaLnBrk="1" fontAlgn="auto" latinLnBrk="0" hangingPunct="1"><a:lnSpc><a:spcPct val="100000"/></a:lnSpc><a:spcBef><a:spcPts val="0"/></a:spcBef><a:spcAft><a:spcPts val="0"/></a:spcAft><a:buClrTx/><a:buSzTx/><a:buFontTx/><a:buNone/><a:tabLst/><a:defRPr/></a:pPr><a:endParaRPr kumimoji="0" lang="en-GB" sz="1800" b="0" i="0" u="none" strike="noStrike" kern="1200" cap="none" spc="0" normalizeH="0" baseline="0" noProof="0"><a:ln><a:noFill/></a:ln><a:solidFill><a:prstClr val="white"/></a:solidFill><a:effectLst/><a:uLnTx/><a:uFillTx/><a:latin typeface="Arial"/><a:ea typeface="+mn-ea"/><a:cs typeface="+mn-cs"/></a:endParaRPr></a:p></p:txBody></p:sp><p:sp><p:nvSpPr><p:cNvPr id="2" name="Title 1"><a:extLst><a:ext uri="{FF2B5EF4-FFF2-40B4-BE49-F238E27FC236}"><a16:creationId xmlns:a16="http://schemas.microsoft.com/office/drawing/2014/main" id="{C4B0C193-8E41-6707-3351-166428296020}"/></a:ext></a:extLst></p:cNvPr><p:cNvSpPr><a:spLocks noGrp="1"/></p:cNvSpPr><p:nvPr><p:ph type="ctrTitle" hasCustomPrompt="1"/></p:nvPr></p:nvSpPr><p:spPr><a:xfrm><a:off x="327212" y="1434783"/><a:ext cx="5624008" cy="2387600"/></a:xfrm></p:spPr><p:txBody><a:bodyPr anchor="b"><a:normAutofit/></a:bodyPr><a:lstStyle><a:lvl1pPr algn="l"><a:lnSpc><a:spcPts val="5750"/></a:lnSpc><a:defRPr sz="5500" b="1"><a:solidFill><a:schemeClr val="bg1"/></a:solidFill></a:defRPr></a:lvl1pPr></a:lstStyle><a:p><a:r><a:rPr lang="en-GB" dirty="0"/><a:t>Presentation title to go here</a:t></a:r></a:p></p:txBody></p:sp><p:sp><p:nvSpPr><p:cNvPr id="3" name="Subtitle 2"><a:extLst><a:ext uri="{FF2B5EF4-FFF2-40B4-BE49-F238E27FC236}"><a16:creationId xmlns:a16="http://schemas.microsoft.com/office/drawing/2014/main" id="{2C0F1F9E-70F8-6DF6-E31B-DC33CEB7F560}"/></a:ext></a:extLst></p:cNvPr><p:cNvSpPr><a:spLocks noGrp="1"/></p:cNvSpPr><p:nvPr><p:ph type="subTitle" idx="1"/></p:nvPr></p:nvSpPr><p:spPr><a:xfrm><a:off x="327212" y="3944938"/><a:ext cx="5624008" cy="688022"/></a:xfrm></p:spPr><p:txBody><a:bodyPr><a:normAutofit/></a:bodyPr><a:lstStyle><a:lvl1pPr marL="0" indent="0" algn="l"><a:lnSpc><a:spcPts val="1500"/></a:lnSpc><a:buNone/><a:defRPr sz="1700" b="1"><a:solidFill><a:schemeClr val="bg1"/></a:solidFill><a:latin typeface="+mj-lt"/></a:defRPr></a:lvl1pPr><a:lvl2pPr marL="457200" indent="0" algn="ctr"><a:buNone/><a:defRPr sz="2000"/></a:lvl2pPr><a:lvl3pPr marL="914400" indent="0" algn="ctr"><a:buNone/><a:defRPr sz="1800"/></a:lvl3pPr><a:lvl4pPr marL="1371600" indent="0" algn="ctr"><a:buNone/><a:defRPr sz="1600"/></a:lvl4pPr><a:lvl5pPr marL="1828800" indent="0" algn="ctr"><a:buNone/><a:defRPr sz="1600"/></a:lvl5pPr><a:lvl6pPr marL="2286000" indent="0" algn="ctr"><a:buNone/><a:defRPr sz="1600"/></a:lvl6pPr><a:lvl7pPr marL="2743200" indent="0" algn="ctr"><a:buNone/><a:defRPr sz="1600"/></a:lvl7pPr><a:lvl8pPr marL="3200400" indent="0" algn="ctr"><a:buNone/><a:defRPr sz="1600"/></a:lvl8pPr><a:lvl9pPr marL="3657600" indent="0" algn="ctr"><a:buNone/><a:defRPr sz="1600"/></a:lvl9pPr></a:lstStyle><a:p><a:r><a:rPr lang="en-GB" dirty="0"/><a:t>Click to edit Master subtitle style</a:t></a:r></a:p></p:txBody></p:sp><p:sp><p:nvSpPr><p:cNvPr id="11" name="Text Placeholder 2"><a:extLst><a:ext uri="{FF2B5EF4-FFF2-40B4-BE49-F238E27FC236}"><a16:creationId xmlns:a16="http://schemas.microsoft.com/office/drawing/2014/main" id="{477DA420-8D5A-23E7-54F3-B3B5B52C9CE7}"/></a:ext></a:extLst></p:cNvPr><p:cNvSpPr><a:spLocks noGrp="1"/></p:cNvSpPr><p:nvPr><p:ph type="body" idx="10" hasCustomPrompt="1"/></p:nvPr></p:nvSpPr><p:spPr><a:xfrm><a:off x="327212" y="6263639"/><a:ext cx="5157787" cy="226695"/></a:xfrm></p:spPr><p:txBody><a:bodyPr anchor="t" anchorCtr="0"><a:normAutofit/></a:bodyPr><a:lstStyle><a:lvl1pPr marL="0" indent="0"><a:buNone/><a:defRPr sz="1200" b="0"><a:solidFill><a:schemeClr val="bg1"/></a:solidFill></a:defRPr></a:lvl1pPr><a:lvl2pPr marL="457200" indent="0"><a:buNone/><a:defRPr sz="2000" b="1"/></a:lvl2pPr><a:lvl3pPr marL="914400" indent="0"><a:buNone/><a:defRPr sz="1800" b="1"/></a:lvl3pPr><a:lvl4pPr marL="1371600" indent="0"><a:buNone/><a:defRPr sz="1600" b="1"/></a:lvl4pPr><a:lvl5pPr marL="1828800" indent="0"><a:buNone/><a:defRPr sz="1600" b="1"/></a:lvl5pPr><a:lvl6pPr marL="2286000" indent="0"><a:buNone/><a:defRPr sz="1600" b="1"/></a:lvl6pPr><a:lvl7pPr marL="2743200" indent="0"><a:buNone/><a:defRPr sz="1600" b="1"/></a:lvl7pPr><a:lvl8pPr marL="3200400" indent="0"><a:buNone/><a:defRPr sz="1600" b="1"/></a:lvl8pPr><a:lvl9pPr marL="3657600" indent="0"><a:buNone/><a:defRPr sz="1600" b="1"/></a:lvl9pPr></a:lstStyle><a:p><a:pPr lvl="0"/><a:r><a:rPr lang="en-GB" dirty="0"/><a:t>Month 2024</a:t></a:r></a:p></p:txBody></p:sp><p:cxnSp><p:nvCxnSpPr><p:cNvPr id="13" name="Straight Connector 12"><a:extLst><a:ext uri="{FF2B5EF4-FFF2-40B4-BE49-F238E27FC236}"><a16:creationId xmlns:a16="http://schemas.microsoft.com/office/drawing/2014/main" id="{8B2CAB68-9D55-B14B-E43A-8B4203B3178A}"/></a:ext></a:extLst></p:cNvPr><p:cNvCxnSpPr><a:cxnSpLocks/></p:cNvCxnSpPr><p:nvPr userDrawn="1"/></p:nvCxnSpPr><p:spPr><a:xfrm><a:off x="327212" y="6050280"/><a:ext cx="5570668" cy="0"/></a:xfrm><a:prstGeom prst="line"><a:avLst/></a:prstGeom><a:ln w="6350"><a:solidFill><a:schemeClr val="bg1"/></a:solidFill></a:ln></p:spPr><p:style><a:lnRef idx="2"><a:schemeClr val="accent1"/></a:lnRef><a:fillRef idx="0"><a:schemeClr val="accent1"/></a:fillRef><a:effectRef idx="1"><a:schemeClr val="accent1"/></a:effectRef><a:fontRef idx="minor"><a:schemeClr val="tx1"/></a:fontRef></p:style></p:cxnSp><p:pic><p:nvPicPr><p:cNvPr id="14" name="Picture 13" descr="A black background with white text&#xA;&#xA;Description automatically generated"><a:extLst><a:ext uri="{FF2B5EF4-FFF2-40B4-BE49-F238E27FC236}"><a16:creationId xmlns:a16="http://schemas.microsoft.com/office/drawing/2014/main" id="{DCECEB61-B27B-7F56-056B-194CD80CAA59}"/></a:ext></a:extLst></p:cNvPr><p:cNvPicPr><a:picLocks noChangeAspect="1"/></p:cNvPicPr><p:nvPr userDrawn="1"/></p:nvPicPr><p:blipFill><a:blip r:embed="rId2" cstate="screen"><a:extLst><a:ext uri="{28A0092B-C50C-407E-A947-70E740481C1C}"><a14:useLocalDpi xmlns:a14="http://schemas.microsoft.com/office/drawing/2010/main"/></a:ext></a:extLst></a:blip><a:stretch><a:fillRect/></a:stretch></p:blipFill><p:spPr><a:xfrm><a:off x="327212" y="298262"/><a:ext cx="1683977" cy="387538"/></a:xfrm><a:prstGeom prst="rect"><a:avLst/></a:prstGeom></p:spPr></p:pic></p:spTree><p:extLst><p:ext uri="{BB962C8B-B14F-4D97-AF65-F5344CB8AC3E}"><p14:creationId xmlns:p14="http://schemas.microsoft.com/office/powerpoint/2010/main" val="1389909116"/></p:ext></p:extLst></p:cSld><p:clrMapOvr><a:masterClrMapping/></p:clrMapOvr><p:extLst><p:ext uri="{DCECCB84-F9BA-43D5-87BE-67443E8EF086}"><p15:sldGuideLst xmlns:p15="http://schemas.microsoft.com/office/powerpoint/2012/main"><p15:guide id="1" orient="horz" pos="2160" userDrawn="1"><p15:clr><a:srgbClr val="FBAE40"/></p15:clr></p15:guide><p15:guide id="2" pos="3840" userDrawn="1"><p15:clr><a:srgbClr val="FBAE40"/></p15:clr></p15:guide></p15:sldGuideLst></p:ext></p:extLst></p:sldLayout>
+<p:sldLayout xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main"
+  xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships"
+  xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main" preserve="1" userDrawn="1">
+  <p:cSld name="Cover slide">
+    <p:spTree>
+      <p:nvGrpSpPr>
+        <p:cNvPr id="1" name="" />
+        <p:cNvGrpSpPr />
+        <p:nvPr />
+      </p:nvGrpSpPr>
+      <p:grpSpPr>
+        <a:xfrm>
+          <a:off x="0" y="0" />
+          <a:ext cx="0" cy="0" />
+          <a:chOff x="0" y="0" />
+          <a:chExt cx="0" cy="0" />
+        </a:xfrm>
+      </p:grpSpPr>
+      <p:sp>
+        <p:nvSpPr>
+          <p:cNvPr id="5" name="Picture Placeholder 4">
+            <a:extLst>
+              <a:ext uri="{FF2B5EF4-FFF2-40B4-BE49-F238E27FC236}">
+                <a16:creationId xmlns:a16="http://schemas.microsoft.com/office/drawing/2014/main"
+                  id="{C21B7C50-4A8F-0D4C-20DA-5E2A38CCF56B}" />
+              </a:ext>
+            </a:extLst>
+          </p:cNvPr>
+          <p:cNvSpPr>
+            <a:spLocks noGrp="1" />
+          </p:cNvSpPr>
+          <p:nvPr>
+            <p:ph type="pic" sz="quarter" idx="11" />
+          </p:nvPr>
+        </p:nvSpPr>
+        <p:spPr>
+          <a:xfrm>
+            <a:off x="0" y="0" />
+            <a:ext cx="12192000" cy="6858000" />
+          </a:xfrm>
+        </p:spPr>
+        <p:txBody>
+          <a:bodyPr />
+          <a:lstStyle />
+          <a:p>
+            <a:endParaRPr lang="en-GB" />
+          </a:p>
+        </p:txBody>
+      </p:sp>
+      <p:sp>
+        <p:nvSpPr>
+          <p:cNvPr id="4" name="Rectangle 3">
+            <a:extLst>
+              <a:ext uri="{FF2B5EF4-FFF2-40B4-BE49-F238E27FC236}">
+                <a16:creationId xmlns:a16="http://schemas.microsoft.com/office/drawing/2014/main"
+                  id="{D1169294-B756-930B-63EB-DA74F80322B7}" />
+              </a:ext>
+            </a:extLst>
+          </p:cNvPr>
+          <p:cNvSpPr />
+          <p:nvPr userDrawn="1" />
+        </p:nvSpPr>
+        <p:spPr>
+          <a:xfrm flipH="1">
+            <a:off x="0" y="0" />
+            <a:ext cx="12192000" cy="6858000" />
+          </a:xfrm>
+          <a:prstGeom prst="rect">
+            <a:avLst />
+          </a:prstGeom>
+          <a:gradFill>
+            <a:gsLst>
+              <a:gs pos="25990">
+                <a:srgbClr val="29005A">
+                  <a:alpha val="48000" />
+                </a:srgbClr>
+              </a:gs>
+              <a:gs pos="78000">
+                <a:schemeClr val="tx2" />
+              </a:gs>
+              <a:gs pos="50000">
+                <a:schemeClr val="tx2">
+                  <a:alpha val="89069" />
+                </a:schemeClr>
+              </a:gs>
+              <a:gs pos="0">
+                <a:schemeClr val="tx2">
+                  <a:alpha val="60207" />
+                </a:schemeClr>
+              </a:gs>
+              <a:gs pos="100000">
+                <a:schemeClr val="accent3">
+                  <a:lumMod val="10000" />
+                </a:schemeClr>
+              </a:gs>
+            </a:gsLst>
+            <a:lin ang="0" scaled="0" />
+          </a:gradFill>
+          <a:ln>
+            <a:noFill />
+          </a:ln>
+        </p:spPr>
+        <p:style>
+          <a:lnRef idx="2">
+            <a:schemeClr val="accent1">
+              <a:shade val="15000" />
+            </a:schemeClr>
+          </a:lnRef>
+          <a:fillRef idx="1">
+            <a:schemeClr val="accent1" />
+          </a:fillRef>
+          <a:effectRef idx="0">
+            <a:schemeClr val="accent1" />
+          </a:effectRef>
+          <a:fontRef idx="minor">
+            <a:schemeClr val="lt1" />
+          </a:fontRef>
+        </p:style>
+        <p:txBody>
+          <a:bodyPr rtlCol="0" anchor="ctr" />
+          <a:lstStyle />
+          <a:p>
+            <a:pPr marL="0" marR="0" lvl="0" indent="0" algn="ctr" defTabSz="914400" rtl="0"
+              eaLnBrk="1" fontAlgn="auto" latinLnBrk="0" hangingPunct="1">
+              <a:lnSpc>
+                <a:spcPct val="100000" />
+              </a:lnSpc>
+              <a:spcBef>
+                <a:spcPts val="0" />
+              </a:spcBef>
+              <a:spcAft>
+                <a:spcPts val="0" />
+              </a:spcAft>
+              <a:buClrTx />
+              <a:buSzTx />
+              <a:buFontTx />
+              <a:buNone />
+              <a:tabLst />
+              <a:defRPr />
+            </a:pPr>
+            <a:endParaRPr kumimoji="0" lang="en-GB" sz="1800" b="0" i="0" u="none" strike="noStrike"
+              kern="1200" cap="none" spc="0" normalizeH="0" baseline="0" noProof="0">
+              <a:ln>
+                <a:noFill />
+              </a:ln>
+              <a:solidFill>
+                <a:prstClr val="white" />
+              </a:solidFill>
+              <a:effectLst />
+              <a:uLnTx />
+              <a:uFillTx />
+              <a:latin typeface="Arial" />
+              <a:ea typeface="+mn-ea" />
+              <a:cs typeface="+mn-cs" />
+            </a:endParaRPr>
+          </a:p>
+        </p:txBody>
+      </p:sp>
+      <p:sp>
+        <p:nvSpPr>
+          <p:cNvPr id="2" name="Title 1">
+            <a:extLst>
+              <a:ext uri="{FF2B5EF4-FFF2-40B4-BE49-F238E27FC236}">
+                <a16:creationId xmlns:a16="http://schemas.microsoft.com/office/drawing/2014/main"
+                  id="{C4B0C193-8E41-6707-3351-166428296020}" />
+              </a:ext>
+            </a:extLst>
+          </p:cNvPr>
+          <p:cNvSpPr>
+            <a:spLocks noGrp="1" />
+          </p:cNvSpPr>
+          <p:nvPr>
+            <p:ph type="ctrTitle" hasCustomPrompt="1" />
+          </p:nvPr>
+        </p:nvSpPr>
+        <p:spPr>
+          <a:xfrm>
+            <a:off x="327212" y="1434783" />
+            <a:ext cx="5624008" cy="2387600" />
+          </a:xfrm>
+        </p:spPr>
+        <p:txBody>
+          <a:bodyPr anchor="b">
+            <a:normAutofit />
+          </a:bodyPr>
+          <a:lstStyle>
+            <a:lvl1pPr algn="l">
+              <a:lnSpc>
+                <a:spcPts val="5750" />
+              </a:lnSpc>
+              <a:defRPr sz="4000" b="1">
+                <a:solidFill>
+                  <a:schemeClr val="bg1" />
+                </a:solidFill>
+              </a:defRPr>
+            </a:lvl1pPr>
+          </a:lstStyle>
+          <a:p>
+            <a:r>
+              <a:rPr lang="en-GB" dirty="0" />
+              <a:t>Presentation title to go here</a:t>
+            </a:r>
+          </a:p>
+        </p:txBody>
+      </p:sp>
+      <p:sp>
+        <p:nvSpPr>
+          <p:cNvPr id="3" name="Subtitle 2">
+            <a:extLst>
+              <a:ext uri="{FF2B5EF4-FFF2-40B4-BE49-F238E27FC236}">
+                <a16:creationId xmlns:a16="http://schemas.microsoft.com/office/drawing/2014/main"
+                  id="{2C0F1F9E-70F8-6DF6-E31B-DC33CEB7F560}" />
+              </a:ext>
+            </a:extLst>
+          </p:cNvPr>
+          <p:cNvSpPr>
+            <a:spLocks noGrp="1" />
+          </p:cNvSpPr>
+          <p:nvPr>
+            <p:ph type="subTitle" idx="1" />
+          </p:nvPr>
+        </p:nvSpPr>
+        <p:spPr>
+          <a:xfrm>
+            <a:off x="327212" y="3944938" />
+            <a:ext cx="5624008" cy="688022" />
+          </a:xfrm>
+        </p:spPr>
+        <p:txBody>
+          <a:bodyPr>
+            <a:normAutofit />
+          </a:bodyPr>
+          <a:lstStyle>
+            <a:lvl1pPr marL="0" indent="0" algn="l">
+              <a:lnSpc>
+                <a:spcPts val="1500" />
+              </a:lnSpc>
+              <a:buNone />
+              <a:defRPr sz="1700" b="1">
+                <a:solidFill>
+                  <a:schemeClr val="bg1" />
+                </a:solidFill>
+                <a:latin typeface="+mj-lt" />
+              </a:defRPr>
+            </a:lvl1pPr>
+            <a:lvl2pPr marL="457200" indent="0" algn="ctr">
+              <a:buNone />
+              <a:defRPr sz="2000" />
+            </a:lvl2pPr>
+            <a:lvl3pPr marL="914400" indent="0" algn="ctr">
+              <a:buNone />
+              <a:defRPr sz="1800" />
+            </a:lvl3pPr>
+            <a:lvl4pPr marL="1371600" indent="0" algn="ctr">
+              <a:buNone />
+              <a:defRPr sz="1600" />
+            </a:lvl4pPr>
+            <a:lvl5pPr marL="1828800" indent="0" algn="ctr">
+              <a:buNone />
+              <a:defRPr sz="1600" />
+            </a:lvl5pPr>
+            <a:lvl6pPr marL="2286000" indent="0" algn="ctr">
+              <a:buNone />
+              <a:defRPr sz="1600" />
+            </a:lvl6pPr>
+            <a:lvl7pPr marL="2743200" indent="0" algn="ctr">
+              <a:buNone />
+              <a:defRPr sz="1600" />
+            </a:lvl7pPr>
+            <a:lvl8pPr marL="3200400" indent="0" algn="ctr">
+              <a:buNone />
+              <a:defRPr sz="1600" />
+            </a:lvl8pPr>
+            <a:lvl9pPr marL="3657600" indent="0" algn="ctr">
+              <a:buNone />
+              <a:defRPr sz="1600" />
+            </a:lvl9pPr>
+          </a:lstStyle>
+          <a:p>
+            <a:r>
+              <a:rPr lang="en-GB" dirty="0" />
+              <a:t>Click to edit Master subtitle style</a:t>
+            </a:r>
+          </a:p>
+        </p:txBody>
+      </p:sp>
+      <p:sp>
+        <p:nvSpPr>
+          <p:cNvPr id="11" name="Text Placeholder 2">
+            <a:extLst>
+              <a:ext uri="{FF2B5EF4-FFF2-40B4-BE49-F238E27FC236}">
+                <a16:creationId xmlns:a16="http://schemas.microsoft.com/office/drawing/2014/main"
+                  id="{477DA420-8D5A-23E7-54F3-B3B5B52C9CE7}" />
+              </a:ext>
+            </a:extLst>
+          </p:cNvPr>
+          <p:cNvSpPr>
+            <a:spLocks noGrp="1" />
+          </p:cNvSpPr>
+          <p:nvPr>
+            <p:ph type="body" idx="10" hasCustomPrompt="1" />
+          </p:nvPr>
+        </p:nvSpPr>
+        <p:spPr>
+          <a:xfrm>
+            <a:off x="327212" y="6263639" />
+            <a:ext cx="5157787" cy="226695" />
+          </a:xfrm>
+        </p:spPr>
+        <p:txBody>
+          <a:bodyPr anchor="t" anchorCtr="0">
+            <a:normAutofit />
+          </a:bodyPr>
+          <a:lstStyle>
+            <a:lvl1pPr marL="0" indent="0">
+              <a:buNone />
+              <a:defRPr sz="1200" b="0">
+                <a:solidFill>
+                  <a:schemeClr val="bg1" />
+                </a:solidFill>
+              </a:defRPr>
+            </a:lvl1pPr>
+            <a:lvl2pPr marL="457200" indent="0">
+              <a:buNone />
+              <a:defRPr sz="2000" b="1" />
+            </a:lvl2pPr>
+            <a:lvl3pPr marL="914400" indent="0">
+              <a:buNone />
+              <a:defRPr sz="1800" b="1" />
+            </a:lvl3pPr>
+            <a:lvl4pPr marL="1371600" indent="0">
+              <a:buNone />
+              <a:defRPr sz="1600" b="1" />
+            </a:lvl4pPr>
+            <a:lvl5pPr marL="1828800" indent="0">
+              <a:buNone />
+              <a:defRPr sz="1600" b="1" />
+            </a:lvl5pPr>
+            <a:lvl6pPr marL="2286000" indent="0">
+              <a:buNone />
+              <a:defRPr sz="1600" b="1" />
+            </a:lvl6pPr>
+            <a:lvl7pPr marL="2743200" indent="0">
+              <a:buNone />
+              <a:defRPr sz="1600" b="1" />
+            </a:lvl7pPr>
+            <a:lvl8pPr marL="3200400" indent="0">
+              <a:buNone />
+              <a:defRPr sz="1600" b="1" />
+            </a:lvl8pPr>
+            <a:lvl9pPr marL="3657600" indent="0">
+              <a:buNone />
+              <a:defRPr sz="1600" b="1" />
+            </a:lvl9pPr>
+          </a:lstStyle>
+          <a:p>
+            <a:pPr lvl="0" />
+            <a:r>
+              <a:rPr lang="en-GB" dirty="0" />
+              <a:t>Month 2024</a:t>
+            </a:r>
+          </a:p>
+        </p:txBody>
+      </p:sp>
+      <p:cxnSp>
+        <p:nvCxnSpPr>
+          <p:cNvPr id="13" name="Straight Connector 12">
+            <a:extLst>
+              <a:ext uri="{FF2B5EF4-FFF2-40B4-BE49-F238E27FC236}">
+                <a16:creationId xmlns:a16="http://schemas.microsoft.com/office/drawing/2014/main"
+                  id="{8B2CAB68-9D55-B14B-E43A-8B4203B3178A}" />
+              </a:ext>
+            </a:extLst>
+          </p:cNvPr>
+          <p:cNvCxnSpPr>
+            <a:cxnSpLocks />
+          </p:cNvCxnSpPr>
+          <p:nvPr userDrawn="1" />
+        </p:nvCxnSpPr>
+        <p:spPr>
+          <a:xfrm>
+            <a:off x="327212" y="6050280" />
+            <a:ext cx="5570668" cy="0" />
+          </a:xfrm>
+          <a:prstGeom prst="line">
+            <a:avLst />
+          </a:prstGeom>
+          <a:ln w="6350">
+            <a:solidFill>
+              <a:schemeClr val="bg1" />
+            </a:solidFill>
+          </a:ln>
+        </p:spPr>
+        <p:style>
+          <a:lnRef idx="2">
+            <a:schemeClr val="accent1" />
+          </a:lnRef>
+          <a:fillRef idx="0">
+            <a:schemeClr val="accent1" />
+          </a:fillRef>
+          <a:effectRef idx="1">
+            <a:schemeClr val="accent1" />
+          </a:effectRef>
+          <a:fontRef idx="minor">
+            <a:schemeClr val="tx1" />
+          </a:fontRef>
+        </p:style>
+      </p:cxnSp>
+      <p:pic>
+        <p:nvPicPr>
+          <p:cNvPr id="14" name="Picture 13"
+            descr="A black background with white text&#xA;&#xA;Description automatically generated">
+            <a:extLst>
+              <a:ext uri="{FF2B5EF4-FFF2-40B4-BE49-F238E27FC236}">
+                <a16:creationId xmlns:a16="http://schemas.microsoft.com/office/drawing/2014/main"
+                  id="{DCECEB61-B27B-7F56-056B-194CD80CAA59}" />
+              </a:ext>
+            </a:extLst>
+          </p:cNvPr>
+          <p:cNvPicPr>
+            <a:picLocks noChangeAspect="1" />
+          </p:cNvPicPr>
+          <p:nvPr userDrawn="1" />
+        </p:nvPicPr>
+        <p:blipFill>
+          <a:blip r:embed="rId2" cstate="screen">
+            <a:extLst>
+              <a:ext uri="{28A0092B-C50C-407E-A947-70E740481C1C}">
+                <a14:useLocalDpi xmlns:a14="http://schemas.microsoft.com/office/drawing/2010/main" />
+              </a:ext>
+            </a:extLst>
+          </a:blip>
+          <a:stretch>
+            <a:fillRect />
+          </a:stretch>
+        </p:blipFill>
+        <p:spPr>
+          <a:xfrm>
+            <a:off x="327212" y="298262" />
+            <a:ext cx="1683977" cy="387538" />
+          </a:xfrm>
+          <a:prstGeom prst="rect">
+            <a:avLst />
+          </a:prstGeom>
+        </p:spPr>
+      </p:pic>
+    </p:spTree>
+    <p:extLst>
+      <p:ext uri="{BB962C8B-B14F-4D97-AF65-F5344CB8AC3E}">
+        <p14:creationId xmlns:p14="http://schemas.microsoft.com/office/powerpoint/2010/main"
+          val="1389909116" />
+      </p:ext>
+    </p:extLst>
+  </p:cSld>
+  <p:clrMapOvr>
+    <a:masterClrMapping />
+  </p:clrMapOvr>
+  <p:extLst>
+    <p:ext uri="{DCECCB84-F9BA-43D5-87BE-67443E8EF086}">
+      <p15:sldGuideLst xmlns:p15="http://schemas.microsoft.com/office/powerpoint/2012/main">
+        <p15:guide id="1" orient="horz" pos="2160" userDrawn="1">
+          <p15:clr>
+            <a:srgbClr val="FBAE40" />
+          </p15:clr>
+        </p15:guide>
+        <p15:guide id="2" pos="3840" userDrawn="1">
+          <p15:clr>
+            <a:srgbClr val="FBAE40" />
+          </p15:clr>
+        </p15:guide>
+      </p15:sldGuideLst>
+    </p:ext>
+  </p:extLst>
+</p:sldLayout>

--- a/templates/collision-2025-template/ppt/slideLayouts/slideLayout14.xml
+++ b/templates/collision-2025-template/ppt/slideLayouts/slideLayout14.xml
@@ -3,6 +3,14 @@
   xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships"
   xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main" preserve="1" userDrawn="1">
   <p:cSld name="Commercial volume chart component">
+    <p:bg>
+      <p:bgPr>
+        <a:solidFill>
+          <a:prstClr val="white" />
+        </a:solidFill>
+        <a:effectLst />
+      </p:bgPr>
+    </p:bg>
     <p:spTree>
       <p:nvGrpSpPr>
         <p:cNvPr id="1" name="" />

--- a/templates/collision-2025-template/ppt/slideLayouts/slideLayout9.xml
+++ b/templates/collision-2025-template/ppt/slideLayouts/slideLayout9.xml
@@ -1,2 +1,2388 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<p:sldLayout xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships" xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main" preserve="1" userDrawn="1"><p:cSld name="What will happen next component"><p:bg><p:bgPr><a:solidFill><a:schemeClr val="bg1"/></a:solidFill><a:effectLst/></p:bgPr></p:bg><p:spTree><p:nvGrpSpPr><p:cNvPr id="1" name=""/><p:cNvGrpSpPr/><p:nvPr/></p:nvGrpSpPr><p:grpSpPr><a:xfrm><a:off x="0" y="0"/><a:ext cx="0" cy="0"/><a:chOff x="0" y="0"/><a:chExt cx="0" cy="0"/></a:xfrm></p:grpSpPr><p:sp><p:nvSpPr><p:cNvPr id="3" name="Slide Number Placeholder 2"><a:extLst><a:ext uri="{FF2B5EF4-FFF2-40B4-BE49-F238E27FC236}"><a16:creationId xmlns:a16="http://schemas.microsoft.com/office/drawing/2014/main" id="{7B13548D-5456-D7B6-AA99-2AC4EB49C4A2}"/></a:ext></a:extLst></p:cNvPr><p:cNvSpPr><a:spLocks noGrp="1"/></p:cNvSpPr><p:nvPr><p:ph type="sldNum" sz="quarter" idx="10"/></p:nvPr></p:nvSpPr><p:spPr/><p:txBody><a:bodyPr/><a:lstStyle/><a:p><a:fld id="{1A1A750F-FD42-4280-B238-1AD3A0FAB732}" type="slidenum"><a:rPr lang="en-GB" smtClean="0"/><a:pPr/><a:t>‹#›</a:t></a:fld><a:endParaRPr lang="en-GB" dirty="0"/></a:p></p:txBody></p:sp><p:graphicFrame><p:nvGraphicFramePr><p:cNvPr id="7" name="Content Placeholder 18"><a:extLst><a:ext uri="{FF2B5EF4-FFF2-40B4-BE49-F238E27FC236}"><a16:creationId xmlns:a16="http://schemas.microsoft.com/office/drawing/2014/main" id="{257749DA-EC4E-4B77-3BF4-B75072818AD9}"/></a:ext></a:extLst></p:cNvPr><p:cNvGraphicFramePr><a:graphicFrameLocks/></p:cNvGraphicFramePr><p:nvPr userDrawn="1"><p:extLst><p:ext uri="{D42A27DB-BD31-4B8C-83A1-F6EECF244321}"><p14:modId xmlns:p14="http://schemas.microsoft.com/office/powerpoint/2010/main" val="2325708609"/></p:ext></p:extLst></p:nvPr></p:nvGraphicFramePr><p:xfrm><a:off x="334434" y="1628773"/><a:ext cx="11523132" cy="4993719"/></p:xfrm><a:graphic><a:graphicData uri="http://schemas.openxmlformats.org/drawingml/2006/table"><a:tbl><a:tblPr/><a:tblGrid><a:gridCol w="3841044"><a:extLst><a:ext uri="{9D8B030D-6E8A-4147-A177-3AD203B41FA5}"><a16:colId xmlns:a16="http://schemas.microsoft.com/office/drawing/2014/main" val="20000"/></a:ext></a:extLst></a:gridCol><a:gridCol w="3841044"><a:extLst><a:ext uri="{9D8B030D-6E8A-4147-A177-3AD203B41FA5}"><a16:colId xmlns:a16="http://schemas.microsoft.com/office/drawing/2014/main" val="20002"/></a:ext></a:extLst></a:gridCol><a:gridCol w="3841044"><a:extLst><a:ext uri="{9D8B030D-6E8A-4147-A177-3AD203B41FA5}"><a16:colId xmlns:a16="http://schemas.microsoft.com/office/drawing/2014/main" val="20004"/></a:ext></a:extLst></a:gridCol></a:tblGrid><a:tr h="874570"><a:tc><a:txBody><a:bodyPr/><a:lstStyle/><a:p><a:pPr algn="l"><a:lnSpc><a:spcPct val="90000"/></a:lnSpc><a:spcAft><a:spcPts val="600"/></a:spcAft></a:pPr><a:endParaRPr lang="en-GB" sz="1600" b="1" spc="-20" dirty="0"><a:solidFill><a:schemeClr val="bg1"/></a:solidFill><a:latin typeface="Arial"/></a:endParaRPr></a:p><a:p><a:pPr algn="l"><a:lnSpc><a:spcPct val="90000"/></a:lnSpc><a:spcAft><a:spcPts val="600"/></a:spcAft></a:pPr><a:endParaRPr lang="en-GB" sz="1600" b="1" spc="-20" dirty="0"><a:solidFill><a:schemeClr val="bg1"/></a:solidFill><a:latin typeface="Arial"/></a:endParaRPr></a:p></a:txBody><a:tcPr marL="192000" marR="192000" anchor="ctr"><a:lnL w="12700" cmpd="sng"><a:noFill/></a:lnL><a:lnR w="19050" cap="flat" cmpd="sng" algn="ctr"><a:noFill/><a:prstDash val="solid"/><a:round/><a:headEnd type="none" w="med" len="med"/><a:tailEnd type="none" w="med" len="med"/></a:lnR><a:lnT w="12700" cap="flat" cmpd="sng" algn="ctr"><a:solidFill><a:srgbClr val="FFFFFF"/></a:solidFill><a:prstDash val="solid"/><a:round/><a:headEnd type="none" w="med" len="med"/><a:tailEnd type="none" w="med" len="med"/></a:lnT><a:lnB w="57150" cap="flat" cmpd="sng" algn="ctr"><a:solidFill><a:schemeClr val="bg1"/></a:solidFill><a:prstDash val="solid"/><a:round/><a:headEnd type="none" w="med" len="med"/><a:tailEnd type="none" w="med" len="med"/></a:lnB><a:lnTlToBr w="12700" cmpd="sng"><a:noFill/><a:prstDash val="solid"/></a:lnTlToBr><a:lnBlToTr w="12700" cmpd="sng"><a:noFill/><a:prstDash val="solid"/></a:lnBlToTr><a:solidFill><a:schemeClr val="bg1"><a:lumMod val="95000"/></a:schemeClr></a:solidFill></a:tcPr></a:tc><a:tc><a:txBody><a:bodyPr/><a:lstStyle/><a:p><a:pPr marL="0" marR="0" lvl="0" indent="0" algn="l" defTabSz="457200" rtl="0" eaLnBrk="1" fontAlgn="auto" latinLnBrk="0" hangingPunct="1"><a:lnSpc><a:spcPct val="90000"/></a:lnSpc><a:spcBef><a:spcPts val="0"/></a:spcBef><a:spcAft><a:spcPts val="600"/></a:spcAft><a:buClrTx/><a:buSzTx/><a:buFontTx/><a:buNone/><a:tabLst/><a:defRPr/></a:pPr><a:endParaRPr lang="en-GB" sz="1600" kern="1200" spc="-20"><a:solidFill><a:schemeClr val="tx1"><a:lumMod val="85000"/><a:lumOff val="15000"/></a:schemeClr></a:solidFill><a:latin typeface="Arial"/><a:ea typeface="+mn-ea"/><a:cs typeface="+mn-cs"/></a:endParaRPr></a:p></a:txBody><a:tcPr marL="192000" marR="192000" anchor="ctr"><a:lnL w="19050" cap="flat" cmpd="sng" algn="ctr"><a:noFill/><a:prstDash val="solid"/><a:round/><a:headEnd type="none" w="med" len="med"/><a:tailEnd type="none" w="med" len="med"/></a:lnL><a:lnR w="19050" cap="flat" cmpd="sng" algn="ctr"><a:noFill/><a:prstDash val="solid"/><a:round/><a:headEnd type="none" w="med" len="med"/><a:tailEnd type="none" w="med" len="med"/></a:lnR><a:lnT w="12700" cap="flat" cmpd="sng" algn="ctr"><a:solidFill><a:srgbClr val="FFFFFF"/></a:solidFill><a:prstDash val="solid"/><a:round/><a:headEnd type="none" w="med" len="med"/><a:tailEnd type="none" w="med" len="med"/></a:lnT><a:lnB w="57150" cap="flat" cmpd="sng" algn="ctr"><a:solidFill><a:schemeClr val="bg1"/></a:solidFill><a:prstDash val="solid"/><a:round/><a:headEnd type="none" w="med" len="med"/><a:tailEnd type="none" w="med" len="med"/></a:lnB><a:lnTlToBr w="12700" cmpd="sng"><a:noFill/><a:prstDash val="solid"/></a:lnTlToBr><a:lnBlToTr w="12700" cmpd="sng"><a:noFill/><a:prstDash val="solid"/></a:lnBlToTr><a:solidFill><a:schemeClr val="tx1"/></a:solidFill></a:tcPr></a:tc><a:tc><a:txBody><a:bodyPr/><a:lstStyle/><a:p><a:pPr marL="0" marR="0" lvl="0" indent="0" algn="l" defTabSz="457200" rtl="0" eaLnBrk="1" fontAlgn="auto" latinLnBrk="0" hangingPunct="1"><a:lnSpc><a:spcPct val="90000"/></a:lnSpc><a:spcBef><a:spcPts val="0"/></a:spcBef><a:spcAft><a:spcPts val="600"/></a:spcAft><a:buClrTx/><a:buSzTx/><a:buFontTx/><a:buNone/><a:tabLst/><a:defRPr/></a:pPr><a:endParaRPr lang="en-GB" sz="1600" kern="1200" spc="-20" dirty="0"><a:solidFill><a:schemeClr val="tx1"><a:lumMod val="85000"/><a:lumOff val="15000"/></a:schemeClr></a:solidFill><a:latin typeface="Arial"/><a:ea typeface="+mn-ea"/><a:cs typeface="+mn-cs"/></a:endParaRPr></a:p></a:txBody><a:tcPr marL="192000" marR="192000" anchor="ctr"><a:lnL w="19050" cap="flat" cmpd="sng" algn="ctr"><a:noFill/><a:prstDash val="solid"/><a:round/><a:headEnd type="none" w="med" len="med"/><a:tailEnd type="none" w="med" len="med"/></a:lnL><a:lnR w="12700" cmpd="sng"><a:noFill/></a:lnR><a:lnT w="12700" cap="flat" cmpd="sng" algn="ctr"><a:solidFill><a:srgbClr val="FFFFFF"/></a:solidFill><a:prstDash val="solid"/><a:round/><a:headEnd type="none" w="med" len="med"/><a:tailEnd type="none" w="med" len="med"/></a:lnT><a:lnB w="57150" cap="flat" cmpd="sng" algn="ctr"><a:solidFill><a:schemeClr val="bg1"/></a:solidFill><a:prstDash val="solid"/><a:round/><a:headEnd type="none" w="med" len="med"/><a:tailEnd type="none" w="med" len="med"/></a:lnB><a:lnTlToBr w="12700" cmpd="sng"><a:noFill/><a:prstDash val="solid"/></a:lnTlToBr><a:lnBlToTr w="12700" cmpd="sng"><a:noFill/><a:prstDash val="solid"/></a:lnBlToTr><a:solidFill><a:schemeClr val="accent1"/></a:solidFill></a:tcPr></a:tc><a:extLst><a:ext uri="{0D108BD9-81ED-4DB2-BD59-A6C34878D82A}"><a16:rowId xmlns:a16="http://schemas.microsoft.com/office/drawing/2014/main" val="1441025099"/></a:ext></a:extLst></a:tr><a:tr h="1363263"><a:tc><a:txBody><a:bodyPr/><a:lstStyle><a:defPPr><a:defRPr lang="en-US"/></a:defPPr><a:lvl1pPr marL="0" algn="l" defTabSz="914400" rtl="0" eaLnBrk="1" latinLnBrk="0" hangingPunct="1"><a:defRPr sz="1800" kern="1200"><a:solidFill><a:schemeClr val="dk1"/></a:solidFill><a:latin typeface="Arial"/></a:defRPr></a:lvl1pPr><a:lvl2pPr marL="457200" algn="l" defTabSz="914400" rtl="0" eaLnBrk="1" latinLnBrk="0" hangingPunct="1"><a:defRPr sz="1800" kern="1200"><a:solidFill><a:schemeClr val="dk1"/></a:solidFill><a:latin typeface="Arial"/></a:defRPr></a:lvl2pPr><a:lvl3pPr marL="914400" algn="l" defTabSz="914400" rtl="0" eaLnBrk="1" latinLnBrk="0" hangingPunct="1"><a:defRPr sz="1800" kern="1200"><a:solidFill><a:schemeClr val="dk1"/></a:solidFill><a:latin typeface="Arial"/></a:defRPr></a:lvl3pPr><a:lvl4pPr marL="1371600" algn="l" defTabSz="914400" rtl="0" eaLnBrk="1" latinLnBrk="0" hangingPunct="1"><a:defRPr sz="1800" kern="1200"><a:solidFill><a:schemeClr val="dk1"/></a:solidFill><a:latin typeface="Arial"/></a:defRPr></a:lvl4pPr><a:lvl5pPr marL="1828800" algn="l" defTabSz="914400" rtl="0" eaLnBrk="1" latinLnBrk="0" hangingPunct="1"><a:defRPr sz="1800" kern="1200"><a:solidFill><a:schemeClr val="dk1"/></a:solidFill><a:latin typeface="Arial"/></a:defRPr></a:lvl5pPr><a:lvl6pPr marL="2286000" algn="l" defTabSz="914400" rtl="0" eaLnBrk="1" latinLnBrk="0" hangingPunct="1"><a:defRPr sz="1800" kern="1200"><a:solidFill><a:schemeClr val="dk1"/></a:solidFill><a:latin typeface="Arial"/></a:defRPr></a:lvl6pPr><a:lvl7pPr marL="2743200" algn="l" defTabSz="914400" rtl="0" eaLnBrk="1" latinLnBrk="0" hangingPunct="1"><a:defRPr sz="1800" kern="1200"><a:solidFill><a:schemeClr val="dk1"/></a:solidFill><a:latin typeface="Arial"/></a:defRPr></a:lvl7pPr><a:lvl8pPr marL="3200400" algn="l" defTabSz="914400" rtl="0" eaLnBrk="1" latinLnBrk="0" hangingPunct="1"><a:defRPr sz="1800" kern="1200"><a:solidFill><a:schemeClr val="dk1"/></a:solidFill><a:latin typeface="Arial"/></a:defRPr></a:lvl8pPr><a:lvl9pPr marL="3657600" algn="l" defTabSz="914400" rtl="0" eaLnBrk="1" latinLnBrk="0" hangingPunct="1"><a:defRPr sz="1800" kern="1200"><a:solidFill><a:schemeClr val="dk1"/></a:solidFill><a:latin typeface="Arial"/></a:defRPr></a:lvl9pPr></a:lstStyle><a:p><a:pPr algn="l"><a:lnSpc><a:spcPct val="90000"/></a:lnSpc><a:spcAft><a:spcPts val="600"/></a:spcAft></a:pPr><a:endParaRPr lang="en-GB" sz="1600" b="1" spc="-20" dirty="0"><a:solidFill><a:schemeClr val="bg1"/></a:solidFill><a:latin typeface="Arial"/></a:endParaRPr></a:p></a:txBody><a:tcPr marL="192000" marR="192000" anchor="ctr"><a:lnL w="12700" cmpd="sng"><a:noFill/></a:lnL><a:lnR w="19050" cap="flat" cmpd="sng" algn="ctr"><a:noFill/><a:prstDash val="solid"/><a:round/><a:headEnd type="none" w="med" len="med"/><a:tailEnd type="none" w="med" len="med"/></a:lnR><a:lnT w="57150" cap="flat" cmpd="sng" algn="ctr"><a:solidFill><a:schemeClr val="bg1"/></a:solidFill><a:prstDash val="solid"/><a:round/><a:headEnd type="none" w="med" len="med"/><a:tailEnd type="none" w="med" len="med"/></a:lnT><a:lnB w="57150" cap="flat" cmpd="sng" algn="ctr"><a:solidFill><a:schemeClr val="bg1"/></a:solidFill><a:prstDash val="solid"/><a:round/><a:headEnd type="none" w="med" len="med"/><a:tailEnd type="none" w="med" len="med"/></a:lnB><a:lnTlToBr w="12700" cmpd="sng"><a:noFill/><a:prstDash val="solid"/></a:lnTlToBr><a:lnBlToTr w="12700" cmpd="sng"><a:noFill/><a:prstDash val="solid"/></a:lnBlToTr><a:solidFill><a:schemeClr val="bg1"><a:lumMod val="95000"/></a:schemeClr></a:solidFill></a:tcPr></a:tc><a:tc><a:txBody><a:bodyPr/><a:lstStyle><a:defPPr><a:defRPr lang="en-US"/></a:defPPr><a:lvl1pPr marL="0" algn="l" defTabSz="914400" rtl="0" eaLnBrk="1" latinLnBrk="0" hangingPunct="1"><a:defRPr sz="1800" kern="1200"><a:solidFill><a:schemeClr val="dk1"/></a:solidFill><a:latin typeface="Arial"/></a:defRPr></a:lvl1pPr><a:lvl2pPr marL="457200" algn="l" defTabSz="914400" rtl="0" eaLnBrk="1" latinLnBrk="0" hangingPunct="1"><a:defRPr sz="1800" kern="1200"><a:solidFill><a:schemeClr val="dk1"/></a:solidFill><a:latin typeface="Arial"/></a:defRPr></a:lvl2pPr><a:lvl3pPr marL="914400" algn="l" defTabSz="914400" rtl="0" eaLnBrk="1" latinLnBrk="0" hangingPunct="1"><a:defRPr sz="1800" kern="1200"><a:solidFill><a:schemeClr val="dk1"/></a:solidFill><a:latin typeface="Arial"/></a:defRPr></a:lvl3pPr><a:lvl4pPr marL="1371600" algn="l" defTabSz="914400" rtl="0" eaLnBrk="1" latinLnBrk="0" hangingPunct="1"><a:defRPr sz="1800" kern="1200"><a:solidFill><a:schemeClr val="dk1"/></a:solidFill><a:latin typeface="Arial"/></a:defRPr></a:lvl4pPr><a:lvl5pPr marL="1828800" algn="l" defTabSz="914400" rtl="0" eaLnBrk="1" latinLnBrk="0" hangingPunct="1"><a:defRPr sz="1800" kern="1200"><a:solidFill><a:schemeClr val="dk1"/></a:solidFill><a:latin typeface="Arial"/></a:defRPr></a:lvl5pPr><a:lvl6pPr marL="2286000" algn="l" defTabSz="914400" rtl="0" eaLnBrk="1" latinLnBrk="0" hangingPunct="1"><a:defRPr sz="1800" kern="1200"><a:solidFill><a:schemeClr val="dk1"/></a:solidFill><a:latin typeface="Arial"/></a:defRPr></a:lvl6pPr><a:lvl7pPr marL="2743200" algn="l" defTabSz="914400" rtl="0" eaLnBrk="1" latinLnBrk="0" hangingPunct="1"><a:defRPr sz="1800" kern="1200"><a:solidFill><a:schemeClr val="dk1"/></a:solidFill><a:latin typeface="Arial"/></a:defRPr></a:lvl7pPr><a:lvl8pPr marL="3200400" algn="l" defTabSz="914400" rtl="0" eaLnBrk="1" latinLnBrk="0" hangingPunct="1"><a:defRPr sz="1800" kern="1200"><a:solidFill><a:schemeClr val="dk1"/></a:solidFill><a:latin typeface="Arial"/></a:defRPr></a:lvl8pPr><a:lvl9pPr marL="3657600" algn="l" defTabSz="914400" rtl="0" eaLnBrk="1" latinLnBrk="0" hangingPunct="1"><a:defRPr sz="1800" kern="1200"><a:solidFill><a:schemeClr val="dk1"/></a:solidFill><a:latin typeface="Arial"/></a:defRPr></a:lvl9pPr></a:lstStyle><a:p><a:pPr marL="0" marR="0" lvl="0" indent="0" algn="l" defTabSz="457200" rtl="0" eaLnBrk="1" fontAlgn="auto" latinLnBrk="0" hangingPunct="1"><a:lnSpc><a:spcPct val="90000"/></a:lnSpc><a:spcBef><a:spcPts val="0"/></a:spcBef><a:spcAft><a:spcPts val="600"/></a:spcAft><a:buClrTx/><a:buSzTx/><a:buFontTx/><a:buNone/><a:tabLst/><a:defRPr/></a:pPr><a:endParaRPr lang="en-GB" sz="1600" kern="1200" spc="-20" dirty="0"><a:solidFill><a:schemeClr val="tx1"><a:lumMod val="85000"/><a:lumOff val="15000"/></a:schemeClr></a:solidFill><a:latin typeface="Arial"/><a:ea typeface="+mn-ea"/><a:cs typeface="+mn-cs"/></a:endParaRPr></a:p></a:txBody><a:tcPr marL="192000" marR="192000" anchor="ctr"><a:lnL w="19050" cap="flat" cmpd="sng" algn="ctr"><a:noFill/><a:prstDash val="solid"/><a:round/><a:headEnd type="none" w="med" len="med"/><a:tailEnd type="none" w="med" len="med"/></a:lnL><a:lnR w="19050" cap="flat" cmpd="sng" algn="ctr"><a:noFill/><a:prstDash val="solid"/><a:round/><a:headEnd type="none" w="med" len="med"/><a:tailEnd type="none" w="med" len="med"/></a:lnR><a:lnT w="57150" cap="flat" cmpd="sng" algn="ctr"><a:solidFill><a:schemeClr val="bg1"/></a:solidFill><a:prstDash val="solid"/><a:round/><a:headEnd type="none" w="med" len="med"/><a:tailEnd type="none" w="med" len="med"/></a:lnT><a:lnB w="57150" cap="flat" cmpd="sng" algn="ctr"><a:solidFill><a:schemeClr val="bg1"/></a:solidFill><a:prstDash val="solid"/><a:round/><a:headEnd type="none" w="med" len="med"/><a:tailEnd type="none" w="med" len="med"/></a:lnB><a:lnTlToBr w="12700" cmpd="sng"><a:noFill/><a:prstDash val="solid"/></a:lnTlToBr><a:lnBlToTr w="12700" cmpd="sng"><a:noFill/><a:prstDash val="solid"/></a:lnBlToTr><a:solidFill><a:schemeClr val="tx1"/></a:solidFill></a:tcPr></a:tc><a:tc><a:txBody><a:bodyPr/><a:lstStyle><a:defPPr><a:defRPr lang="en-US"/></a:defPPr><a:lvl1pPr marL="0" algn="l" defTabSz="914400" rtl="0" eaLnBrk="1" latinLnBrk="0" hangingPunct="1"><a:defRPr sz="1800" kern="1200"><a:solidFill><a:schemeClr val="dk1"/></a:solidFill><a:latin typeface="Arial"/></a:defRPr></a:lvl1pPr><a:lvl2pPr marL="457200" algn="l" defTabSz="914400" rtl="0" eaLnBrk="1" latinLnBrk="0" hangingPunct="1"><a:defRPr sz="1800" kern="1200"><a:solidFill><a:schemeClr val="dk1"/></a:solidFill><a:latin typeface="Arial"/></a:defRPr></a:lvl2pPr><a:lvl3pPr marL="914400" algn="l" defTabSz="914400" rtl="0" eaLnBrk="1" latinLnBrk="0" hangingPunct="1"><a:defRPr sz="1800" kern="1200"><a:solidFill><a:schemeClr val="dk1"/></a:solidFill><a:latin typeface="Arial"/></a:defRPr></a:lvl3pPr><a:lvl4pPr marL="1371600" algn="l" defTabSz="914400" rtl="0" eaLnBrk="1" latinLnBrk="0" hangingPunct="1"><a:defRPr sz="1800" kern="1200"><a:solidFill><a:schemeClr val="dk1"/></a:solidFill><a:latin typeface="Arial"/></a:defRPr></a:lvl4pPr><a:lvl5pPr marL="1828800" algn="l" defTabSz="914400" rtl="0" eaLnBrk="1" latinLnBrk="0" hangingPunct="1"><a:defRPr sz="1800" kern="1200"><a:solidFill><a:schemeClr val="dk1"/></a:solidFill><a:latin typeface="Arial"/></a:defRPr></a:lvl5pPr><a:lvl6pPr marL="2286000" algn="l" defTabSz="914400" rtl="0" eaLnBrk="1" latinLnBrk="0" hangingPunct="1"><a:defRPr sz="1800" kern="1200"><a:solidFill><a:schemeClr val="dk1"/></a:solidFill><a:latin typeface="Arial"/></a:defRPr></a:lvl6pPr><a:lvl7pPr marL="2743200" algn="l" defTabSz="914400" rtl="0" eaLnBrk="1" latinLnBrk="0" hangingPunct="1"><a:defRPr sz="1800" kern="1200"><a:solidFill><a:schemeClr val="dk1"/></a:solidFill><a:latin typeface="Arial"/></a:defRPr></a:lvl7pPr><a:lvl8pPr marL="3200400" algn="l" defTabSz="914400" rtl="0" eaLnBrk="1" latinLnBrk="0" hangingPunct="1"><a:defRPr sz="1800" kern="1200"><a:solidFill><a:schemeClr val="dk1"/></a:solidFill><a:latin typeface="Arial"/></a:defRPr></a:lvl8pPr><a:lvl9pPr marL="3657600" algn="l" defTabSz="914400" rtl="0" eaLnBrk="1" latinLnBrk="0" hangingPunct="1"><a:defRPr sz="1800" kern="1200"><a:solidFill><a:schemeClr val="dk1"/></a:solidFill><a:latin typeface="Arial"/></a:defRPr></a:lvl9pPr></a:lstStyle><a:p><a:pPr marL="0" marR="0" lvl="0" indent="0" algn="l" defTabSz="457200" rtl="0" eaLnBrk="1" fontAlgn="auto" latinLnBrk="0" hangingPunct="1"><a:lnSpc><a:spcPct val="90000"/></a:lnSpc><a:spcBef><a:spcPts val="0"/></a:spcBef><a:spcAft><a:spcPts val="600"/></a:spcAft><a:buClrTx/><a:buSzTx/><a:buFontTx/><a:buNone/><a:tabLst/><a:defRPr/></a:pPr><a:endParaRPr lang="en-GB" sz="1600" kern="1200" spc="-20" dirty="0"><a:solidFill><a:schemeClr val="tx1"><a:lumMod val="85000"/><a:lumOff val="15000"/></a:schemeClr></a:solidFill><a:latin typeface="Arial"/><a:ea typeface="+mn-ea"/><a:cs typeface="+mn-cs"/></a:endParaRPr></a:p></a:txBody><a:tcPr marL="192000" marR="192000" anchor="ctr"><a:lnL w="19050" cap="flat" cmpd="sng" algn="ctr"><a:noFill/><a:prstDash val="solid"/><a:round/><a:headEnd type="none" w="med" len="med"/><a:tailEnd type="none" w="med" len="med"/></a:lnL><a:lnR w="12700" cmpd="sng"><a:noFill/></a:lnR><a:lnT w="57150" cap="flat" cmpd="sng" algn="ctr"><a:solidFill><a:schemeClr val="bg1"/></a:solidFill><a:prstDash val="solid"/><a:round/><a:headEnd type="none" w="med" len="med"/><a:tailEnd type="none" w="med" len="med"/></a:lnT><a:lnB w="57150" cap="flat" cmpd="sng" algn="ctr"><a:solidFill><a:schemeClr val="bg1"/></a:solidFill><a:prstDash val="solid"/><a:round/><a:headEnd type="none" w="med" len="med"/><a:tailEnd type="none" w="med" len="med"/></a:lnB><a:lnTlToBr w="12700" cmpd="sng"><a:noFill/><a:prstDash val="solid"/></a:lnTlToBr><a:lnBlToTr w="12700" cmpd="sng"><a:noFill/><a:prstDash val="solid"/></a:lnBlToTr><a:solidFill><a:schemeClr val="accent1"/></a:solidFill></a:tcPr></a:tc><a:extLst><a:ext uri="{0D108BD9-81ED-4DB2-BD59-A6C34878D82A}"><a16:rowId xmlns:a16="http://schemas.microsoft.com/office/drawing/2014/main" val="10001"/></a:ext></a:extLst></a:tr><a:tr h="1384663"><a:tc><a:txBody><a:bodyPr/><a:lstStyle><a:defPPr><a:defRPr lang="en-US"/></a:defPPr><a:lvl1pPr marL="0" algn="l" defTabSz="914400" rtl="0" eaLnBrk="1" latinLnBrk="0" hangingPunct="1"><a:defRPr sz="1800" kern="1200"><a:solidFill><a:schemeClr val="dk1"/></a:solidFill><a:latin typeface="Arial"/></a:defRPr></a:lvl1pPr><a:lvl2pPr marL="457200" algn="l" defTabSz="914400" rtl="0" eaLnBrk="1" latinLnBrk="0" hangingPunct="1"><a:defRPr sz="1800" kern="1200"><a:solidFill><a:schemeClr val="dk1"/></a:solidFill><a:latin typeface="Arial"/></a:defRPr></a:lvl2pPr><a:lvl3pPr marL="914400" algn="l" defTabSz="914400" rtl="0" eaLnBrk="1" latinLnBrk="0" hangingPunct="1"><a:defRPr sz="1800" kern="1200"><a:solidFill><a:schemeClr val="dk1"/></a:solidFill><a:latin typeface="Arial"/></a:defRPr></a:lvl3pPr><a:lvl4pPr marL="1371600" algn="l" defTabSz="914400" rtl="0" eaLnBrk="1" latinLnBrk="0" hangingPunct="1"><a:defRPr sz="1800" kern="1200"><a:solidFill><a:schemeClr val="dk1"/></a:solidFill><a:latin typeface="Arial"/></a:defRPr></a:lvl4pPr><a:lvl5pPr marL="1828800" algn="l" defTabSz="914400" rtl="0" eaLnBrk="1" latinLnBrk="0" hangingPunct="1"><a:defRPr sz="1800" kern="1200"><a:solidFill><a:schemeClr val="dk1"/></a:solidFill><a:latin typeface="Arial"/></a:defRPr></a:lvl5pPr><a:lvl6pPr marL="2286000" algn="l" defTabSz="914400" rtl="0" eaLnBrk="1" latinLnBrk="0" hangingPunct="1"><a:defRPr sz="1800" kern="1200"><a:solidFill><a:schemeClr val="dk1"/></a:solidFill><a:latin typeface="Arial"/></a:defRPr></a:lvl6pPr><a:lvl7pPr marL="2743200" algn="l" defTabSz="914400" rtl="0" eaLnBrk="1" latinLnBrk="0" hangingPunct="1"><a:defRPr sz="1800" kern="1200"><a:solidFill><a:schemeClr val="dk1"/></a:solidFill><a:latin typeface="Arial"/></a:defRPr></a:lvl7pPr><a:lvl8pPr marL="3200400" algn="l" defTabSz="914400" rtl="0" eaLnBrk="1" latinLnBrk="0" hangingPunct="1"><a:defRPr sz="1800" kern="1200"><a:solidFill><a:schemeClr val="dk1"/></a:solidFill><a:latin typeface="Arial"/></a:defRPr></a:lvl8pPr><a:lvl9pPr marL="3657600" algn="l" defTabSz="914400" rtl="0" eaLnBrk="1" latinLnBrk="0" hangingPunct="1"><a:defRPr sz="1800" kern="1200"><a:solidFill><a:schemeClr val="dk1"/></a:solidFill><a:latin typeface="Arial"/></a:defRPr></a:lvl9pPr></a:lstStyle><a:p><a:pPr algn="l"><a:lnSpc><a:spcPct val="90000"/></a:lnSpc><a:spcAft><a:spcPts val="600"/></a:spcAft></a:pPr><a:endParaRPr lang="en-GB" sz="1600" spc="-20" dirty="0"><a:solidFill><a:schemeClr val="bg1"/></a:solidFill><a:latin typeface="Arial"/></a:endParaRPr></a:p></a:txBody><a:tcPr marL="192000" marR="192000" anchor="ctr"><a:lnL w="12700" cmpd="sng"><a:noFill/></a:lnL><a:lnR w="19050" cap="flat" cmpd="sng" algn="ctr"><a:noFill/><a:prstDash val="solid"/><a:round/><a:headEnd type="none" w="med" len="med"/><a:tailEnd type="none" w="med" len="med"/></a:lnR><a:lnT w="57150" cap="flat" cmpd="sng" algn="ctr"><a:solidFill><a:schemeClr val="bg1"/></a:solidFill><a:prstDash val="solid"/><a:round/><a:headEnd type="none" w="med" len="med"/><a:tailEnd type="none" w="med" len="med"/></a:lnT><a:lnB w="57150" cap="flat" cmpd="sng" algn="ctr"><a:solidFill><a:schemeClr val="bg1"/></a:solidFill><a:prstDash val="solid"/><a:round/><a:headEnd type="none" w="med" len="med"/><a:tailEnd type="none" w="med" len="med"/></a:lnB><a:lnTlToBr w="12700" cmpd="sng"><a:noFill/><a:prstDash val="solid"/></a:lnTlToBr><a:lnBlToTr w="12700" cmpd="sng"><a:noFill/><a:prstDash val="solid"/></a:lnBlToTr><a:solidFill><a:schemeClr val="bg1"><a:lumMod val="95000"/></a:schemeClr></a:solidFill></a:tcPr></a:tc><a:tc><a:txBody><a:bodyPr/><a:lstStyle><a:defPPr><a:defRPr lang="en-US"/></a:defPPr><a:lvl1pPr marL="0" algn="l" defTabSz="914400" rtl="0" eaLnBrk="1" latinLnBrk="0" hangingPunct="1"><a:defRPr sz="1800" kern="1200"><a:solidFill><a:schemeClr val="dk1"/></a:solidFill><a:latin typeface="Arial"/></a:defRPr></a:lvl1pPr><a:lvl2pPr marL="457200" algn="l" defTabSz="914400" rtl="0" eaLnBrk="1" latinLnBrk="0" hangingPunct="1"><a:defRPr sz="1800" kern="1200"><a:solidFill><a:schemeClr val="dk1"/></a:solidFill><a:latin typeface="Arial"/></a:defRPr></a:lvl2pPr><a:lvl3pPr marL="914400" algn="l" defTabSz="914400" rtl="0" eaLnBrk="1" latinLnBrk="0" hangingPunct="1"><a:defRPr sz="1800" kern="1200"><a:solidFill><a:schemeClr val="dk1"/></a:solidFill><a:latin typeface="Arial"/></a:defRPr></a:lvl3pPr><a:lvl4pPr marL="1371600" algn="l" defTabSz="914400" rtl="0" eaLnBrk="1" latinLnBrk="0" hangingPunct="1"><a:defRPr sz="1800" kern="1200"><a:solidFill><a:schemeClr val="dk1"/></a:solidFill><a:latin typeface="Arial"/></a:defRPr></a:lvl4pPr><a:lvl5pPr marL="1828800" algn="l" defTabSz="914400" rtl="0" eaLnBrk="1" latinLnBrk="0" hangingPunct="1"><a:defRPr sz="1800" kern="1200"><a:solidFill><a:schemeClr val="dk1"/></a:solidFill><a:latin typeface="Arial"/></a:defRPr></a:lvl5pPr><a:lvl6pPr marL="2286000" algn="l" defTabSz="914400" rtl="0" eaLnBrk="1" latinLnBrk="0" hangingPunct="1"><a:defRPr sz="1800" kern="1200"><a:solidFill><a:schemeClr val="dk1"/></a:solidFill><a:latin typeface="Arial"/></a:defRPr></a:lvl6pPr><a:lvl7pPr marL="2743200" algn="l" defTabSz="914400" rtl="0" eaLnBrk="1" latinLnBrk="0" hangingPunct="1"><a:defRPr sz="1800" kern="1200"><a:solidFill><a:schemeClr val="dk1"/></a:solidFill><a:latin typeface="Arial"/></a:defRPr></a:lvl7pPr><a:lvl8pPr marL="3200400" algn="l" defTabSz="914400" rtl="0" eaLnBrk="1" latinLnBrk="0" hangingPunct="1"><a:defRPr sz="1800" kern="1200"><a:solidFill><a:schemeClr val="dk1"/></a:solidFill><a:latin typeface="Arial"/></a:defRPr></a:lvl8pPr><a:lvl9pPr marL="3657600" algn="l" defTabSz="914400" rtl="0" eaLnBrk="1" latinLnBrk="0" hangingPunct="1"><a:defRPr sz="1800" kern="1200"><a:solidFill><a:schemeClr val="dk1"/></a:solidFill><a:latin typeface="Arial"/></a:defRPr></a:lvl9pPr></a:lstStyle><a:p><a:pPr marL="0" marR="0" lvl="0" indent="0" algn="l" defTabSz="457200" rtl="0" eaLnBrk="1" fontAlgn="auto" latinLnBrk="0" hangingPunct="1"><a:lnSpc><a:spcPct val="90000"/></a:lnSpc><a:spcBef><a:spcPts val="0"/></a:spcBef><a:spcAft><a:spcPts val="600"/></a:spcAft><a:buClrTx/><a:buSzTx/><a:buFontTx/><a:buNone/><a:tabLst/><a:defRPr/></a:pPr><a:endParaRPr lang="en-GB" sz="1600" kern="1200" spc="-20" dirty="0"><a:solidFill><a:schemeClr val="tx1"><a:lumMod val="85000"/><a:lumOff val="15000"/></a:schemeClr></a:solidFill><a:latin typeface="Arial"/><a:ea typeface="+mn-ea"/><a:cs typeface="+mn-cs"/></a:endParaRPr></a:p></a:txBody><a:tcPr marL="192000" marR="192000" anchor="ctr"><a:lnL w="19050" cap="flat" cmpd="sng" algn="ctr"><a:noFill/><a:prstDash val="solid"/><a:round/><a:headEnd type="none" w="med" len="med"/><a:tailEnd type="none" w="med" len="med"/></a:lnL><a:lnR w="19050" cap="flat" cmpd="sng" algn="ctr"><a:noFill/><a:prstDash val="solid"/><a:round/><a:headEnd type="none" w="med" len="med"/><a:tailEnd type="none" w="med" len="med"/></a:lnR><a:lnT w="57150" cap="flat" cmpd="sng" algn="ctr"><a:solidFill><a:schemeClr val="bg1"/></a:solidFill><a:prstDash val="solid"/><a:round/><a:headEnd type="none" w="med" len="med"/><a:tailEnd type="none" w="med" len="med"/></a:lnT><a:lnB w="57150" cap="flat" cmpd="sng" algn="ctr"><a:solidFill><a:schemeClr val="bg1"/></a:solidFill><a:prstDash val="solid"/><a:round/><a:headEnd type="none" w="med" len="med"/><a:tailEnd type="none" w="med" len="med"/></a:lnB><a:lnTlToBr w="12700" cmpd="sng"><a:noFill/><a:prstDash val="solid"/></a:lnTlToBr><a:lnBlToTr w="12700" cmpd="sng"><a:noFill/><a:prstDash val="solid"/></a:lnBlToTr><a:solidFill><a:schemeClr val="tx1"/></a:solidFill></a:tcPr></a:tc><a:tc><a:txBody><a:bodyPr/><a:lstStyle><a:defPPr><a:defRPr lang="en-US"/></a:defPPr><a:lvl1pPr marL="0" algn="l" defTabSz="914400" rtl="0" eaLnBrk="1" latinLnBrk="0" hangingPunct="1"><a:defRPr sz="1800" kern="1200"><a:solidFill><a:schemeClr val="dk1"/></a:solidFill><a:latin typeface="Arial"/></a:defRPr></a:lvl1pPr><a:lvl2pPr marL="457200" algn="l" defTabSz="914400" rtl="0" eaLnBrk="1" latinLnBrk="0" hangingPunct="1"><a:defRPr sz="1800" kern="1200"><a:solidFill><a:schemeClr val="dk1"/></a:solidFill><a:latin typeface="Arial"/></a:defRPr></a:lvl2pPr><a:lvl3pPr marL="914400" algn="l" defTabSz="914400" rtl="0" eaLnBrk="1" latinLnBrk="0" hangingPunct="1"><a:defRPr sz="1800" kern="1200"><a:solidFill><a:schemeClr val="dk1"/></a:solidFill><a:latin typeface="Arial"/></a:defRPr></a:lvl3pPr><a:lvl4pPr marL="1371600" algn="l" defTabSz="914400" rtl="0" eaLnBrk="1" latinLnBrk="0" hangingPunct="1"><a:defRPr sz="1800" kern="1200"><a:solidFill><a:schemeClr val="dk1"/></a:solidFill><a:latin typeface="Arial"/></a:defRPr></a:lvl4pPr><a:lvl5pPr marL="1828800" algn="l" defTabSz="914400" rtl="0" eaLnBrk="1" latinLnBrk="0" hangingPunct="1"><a:defRPr sz="1800" kern="1200"><a:solidFill><a:schemeClr val="dk1"/></a:solidFill><a:latin typeface="Arial"/></a:defRPr></a:lvl5pPr><a:lvl6pPr marL="2286000" algn="l" defTabSz="914400" rtl="0" eaLnBrk="1" latinLnBrk="0" hangingPunct="1"><a:defRPr sz="1800" kern="1200"><a:solidFill><a:schemeClr val="dk1"/></a:solidFill><a:latin typeface="Arial"/></a:defRPr></a:lvl6pPr><a:lvl7pPr marL="2743200" algn="l" defTabSz="914400" rtl="0" eaLnBrk="1" latinLnBrk="0" hangingPunct="1"><a:defRPr sz="1800" kern="1200"><a:solidFill><a:schemeClr val="dk1"/></a:solidFill><a:latin typeface="Arial"/></a:defRPr></a:lvl7pPr><a:lvl8pPr marL="3200400" algn="l" defTabSz="914400" rtl="0" eaLnBrk="1" latinLnBrk="0" hangingPunct="1"><a:defRPr sz="1800" kern="1200"><a:solidFill><a:schemeClr val="dk1"/></a:solidFill><a:latin typeface="Arial"/></a:defRPr></a:lvl8pPr><a:lvl9pPr marL="3657600" algn="l" defTabSz="914400" rtl="0" eaLnBrk="1" latinLnBrk="0" hangingPunct="1"><a:defRPr sz="1800" kern="1200"><a:solidFill><a:schemeClr val="dk1"/></a:solidFill><a:latin typeface="Arial"/></a:defRPr></a:lvl9pPr></a:lstStyle><a:p><a:pPr marL="0" marR="0" lvl="0" indent="0" algn="l" defTabSz="457200" rtl="0" eaLnBrk="1" fontAlgn="auto" latinLnBrk="0" hangingPunct="1"><a:lnSpc><a:spcPct val="90000"/></a:lnSpc><a:spcBef><a:spcPts val="0"/></a:spcBef><a:spcAft><a:spcPts val="600"/></a:spcAft><a:buClrTx/><a:buSzTx/><a:buFontTx/><a:buNone/><a:tabLst/><a:defRPr/></a:pPr><a:endParaRPr lang="en-GB" sz="1600" kern="1200" spc="-20" dirty="0"><a:solidFill><a:schemeClr val="tx1"><a:lumMod val="85000"/><a:lumOff val="15000"/></a:schemeClr></a:solidFill><a:latin typeface="Arial"/><a:ea typeface="+mn-ea"/><a:cs typeface="+mn-cs"/></a:endParaRPr></a:p></a:txBody><a:tcPr marL="192000" marR="192000" anchor="ctr"><a:lnL w="19050" cap="flat" cmpd="sng" algn="ctr"><a:noFill/><a:prstDash val="solid"/><a:round/><a:headEnd type="none" w="med" len="med"/><a:tailEnd type="none" w="med" len="med"/></a:lnL><a:lnR w="12700" cmpd="sng"><a:noFill/></a:lnR><a:lnT w="57150" cap="flat" cmpd="sng" algn="ctr"><a:solidFill><a:schemeClr val="bg1"/></a:solidFill><a:prstDash val="solid"/><a:round/><a:headEnd type="none" w="med" len="med"/><a:tailEnd type="none" w="med" len="med"/></a:lnT><a:lnB w="57150" cap="flat" cmpd="sng" algn="ctr"><a:solidFill><a:schemeClr val="bg1"/></a:solidFill><a:prstDash val="solid"/><a:round/><a:headEnd type="none" w="med" len="med"/><a:tailEnd type="none" w="med" len="med"/></a:lnB><a:lnTlToBr w="12700" cmpd="sng"><a:noFill/><a:prstDash val="solid"/></a:lnTlToBr><a:lnBlToTr w="12700" cmpd="sng"><a:noFill/><a:prstDash val="solid"/></a:lnBlToTr><a:solidFill><a:schemeClr val="accent1"/></a:solidFill></a:tcPr></a:tc><a:extLst><a:ext uri="{0D108BD9-81ED-4DB2-BD59-A6C34878D82A}"><a16:rowId xmlns:a16="http://schemas.microsoft.com/office/drawing/2014/main" val="10002"/></a:ext></a:extLst></a:tr><a:tr h="1371223"><a:tc><a:txBody><a:bodyPr/><a:lstStyle><a:defPPr><a:defRPr lang="en-US"/></a:defPPr><a:lvl1pPr marL="0" algn="l" defTabSz="914400" rtl="0" eaLnBrk="1" latinLnBrk="0" hangingPunct="1"><a:defRPr sz="1800" kern="1200"><a:solidFill><a:schemeClr val="dk1"/></a:solidFill><a:latin typeface="Arial"/></a:defRPr></a:lvl1pPr><a:lvl2pPr marL="457200" algn="l" defTabSz="914400" rtl="0" eaLnBrk="1" latinLnBrk="0" hangingPunct="1"><a:defRPr sz="1800" kern="1200"><a:solidFill><a:schemeClr val="dk1"/></a:solidFill><a:latin typeface="Arial"/></a:defRPr></a:lvl2pPr><a:lvl3pPr marL="914400" algn="l" defTabSz="914400" rtl="0" eaLnBrk="1" latinLnBrk="0" hangingPunct="1"><a:defRPr sz="1800" kern="1200"><a:solidFill><a:schemeClr val="dk1"/></a:solidFill><a:latin typeface="Arial"/></a:defRPr></a:lvl3pPr><a:lvl4pPr marL="1371600" algn="l" defTabSz="914400" rtl="0" eaLnBrk="1" latinLnBrk="0" hangingPunct="1"><a:defRPr sz="1800" kern="1200"><a:solidFill><a:schemeClr val="dk1"/></a:solidFill><a:latin typeface="Arial"/></a:defRPr></a:lvl4pPr><a:lvl5pPr marL="1828800" algn="l" defTabSz="914400" rtl="0" eaLnBrk="1" latinLnBrk="0" hangingPunct="1"><a:defRPr sz="1800" kern="1200"><a:solidFill><a:schemeClr val="dk1"/></a:solidFill><a:latin typeface="Arial"/></a:defRPr></a:lvl5pPr><a:lvl6pPr marL="2286000" algn="l" defTabSz="914400" rtl="0" eaLnBrk="1" latinLnBrk="0" hangingPunct="1"><a:defRPr sz="1800" kern="1200"><a:solidFill><a:schemeClr val="dk1"/></a:solidFill><a:latin typeface="Arial"/></a:defRPr></a:lvl6pPr><a:lvl7pPr marL="2743200" algn="l" defTabSz="914400" rtl="0" eaLnBrk="1" latinLnBrk="0" hangingPunct="1"><a:defRPr sz="1800" kern="1200"><a:solidFill><a:schemeClr val="dk1"/></a:solidFill><a:latin typeface="Arial"/></a:defRPr></a:lvl7pPr><a:lvl8pPr marL="3200400" algn="l" defTabSz="914400" rtl="0" eaLnBrk="1" latinLnBrk="0" hangingPunct="1"><a:defRPr sz="1800" kern="1200"><a:solidFill><a:schemeClr val="dk1"/></a:solidFill><a:latin typeface="Arial"/></a:defRPr></a:lvl8pPr><a:lvl9pPr marL="3657600" algn="l" defTabSz="914400" rtl="0" eaLnBrk="1" latinLnBrk="0" hangingPunct="1"><a:defRPr sz="1800" kern="1200"><a:solidFill><a:schemeClr val="dk1"/></a:solidFill><a:latin typeface="Arial"/></a:defRPr></a:lvl9pPr></a:lstStyle><a:p><a:pPr algn="l"><a:lnSpc><a:spcPct val="90000"/></a:lnSpc><a:spcAft><a:spcPts val="600"/></a:spcAft></a:pPr><a:endParaRPr lang="en-GB" sz="1600" spc="-20" dirty="0"><a:solidFill><a:schemeClr val="bg1"/></a:solidFill><a:latin typeface="+mj-lt"/></a:endParaRPr></a:p></a:txBody><a:tcPr marL="192000" marR="192000" anchor="ctr"><a:lnL w="12700" cmpd="sng"><a:noFill/></a:lnL><a:lnR w="19050" cap="flat" cmpd="sng" algn="ctr"><a:noFill/><a:prstDash val="solid"/><a:round/><a:headEnd type="none" w="med" len="med"/><a:tailEnd type="none" w="med" len="med"/></a:lnR><a:lnT w="57150" cap="flat" cmpd="sng" algn="ctr"><a:solidFill><a:schemeClr val="bg1"/></a:solidFill><a:prstDash val="solid"/><a:round/><a:headEnd type="none" w="med" len="med"/><a:tailEnd type="none" w="med" len="med"/></a:lnT><a:lnB w="12700" cmpd="sng"><a:noFill/></a:lnB><a:lnTlToBr w="12700" cmpd="sng"><a:noFill/><a:prstDash val="solid"/></a:lnTlToBr><a:lnBlToTr w="12700" cmpd="sng"><a:noFill/><a:prstDash val="solid"/></a:lnBlToTr><a:solidFill><a:schemeClr val="bg1"><a:lumMod val="95000"/></a:schemeClr></a:solidFill></a:tcPr></a:tc><a:tc><a:txBody><a:bodyPr/><a:lstStyle/><a:p><a:endParaRPr lang="en-GB" sz="1600"><a:latin typeface="+mj-lt"/></a:endParaRPr></a:p></a:txBody><a:tcPr marL="192000" marR="192000" anchor="ctr"><a:lnL w="19050" cap="flat" cmpd="sng" algn="ctr"><a:noFill/><a:prstDash val="solid"/><a:round/><a:headEnd type="none" w="med" len="med"/><a:tailEnd type="none" w="med" len="med"/></a:lnL><a:lnR w="19050" cap="flat" cmpd="sng" algn="ctr"><a:noFill/><a:prstDash val="solid"/><a:round/><a:headEnd type="none" w="med" len="med"/><a:tailEnd type="none" w="med" len="med"/></a:lnR><a:lnT w="57150" cap="flat" cmpd="sng" algn="ctr"><a:solidFill><a:schemeClr val="bg1"/></a:solidFill><a:prstDash val="solid"/><a:round/><a:headEnd type="none" w="med" len="med"/><a:tailEnd type="none" w="med" len="med"/></a:lnT><a:lnB w="12700" cmpd="sng"><a:noFill/></a:lnB><a:lnTlToBr w="12700" cmpd="sng"><a:noFill/><a:prstDash val="solid"/></a:lnTlToBr><a:lnBlToTr w="12700" cmpd="sng"><a:noFill/><a:prstDash val="solid"/></a:lnBlToTr><a:solidFill><a:schemeClr val="tx1"/></a:solidFill></a:tcPr></a:tc><a:tc><a:txBody><a:bodyPr/><a:lstStyle><a:defPPr><a:defRPr lang="en-US"/></a:defPPr><a:lvl1pPr marL="0" algn="l" defTabSz="914400" rtl="0" eaLnBrk="1" latinLnBrk="0" hangingPunct="1"><a:defRPr sz="1800" kern="1200"><a:solidFill><a:schemeClr val="dk1"/></a:solidFill><a:latin typeface="Arial"/></a:defRPr></a:lvl1pPr><a:lvl2pPr marL="457200" algn="l" defTabSz="914400" rtl="0" eaLnBrk="1" latinLnBrk="0" hangingPunct="1"><a:defRPr sz="1800" kern="1200"><a:solidFill><a:schemeClr val="dk1"/></a:solidFill><a:latin typeface="Arial"/></a:defRPr></a:lvl2pPr><a:lvl3pPr marL="914400" algn="l" defTabSz="914400" rtl="0" eaLnBrk="1" latinLnBrk="0" hangingPunct="1"><a:defRPr sz="1800" kern="1200"><a:solidFill><a:schemeClr val="dk1"/></a:solidFill><a:latin typeface="Arial"/></a:defRPr></a:lvl3pPr><a:lvl4pPr marL="1371600" algn="l" defTabSz="914400" rtl="0" eaLnBrk="1" latinLnBrk="0" hangingPunct="1"><a:defRPr sz="1800" kern="1200"><a:solidFill><a:schemeClr val="dk1"/></a:solidFill><a:latin typeface="Arial"/></a:defRPr></a:lvl4pPr><a:lvl5pPr marL="1828800" algn="l" defTabSz="914400" rtl="0" eaLnBrk="1" latinLnBrk="0" hangingPunct="1"><a:defRPr sz="1800" kern="1200"><a:solidFill><a:schemeClr val="dk1"/></a:solidFill><a:latin typeface="Arial"/></a:defRPr></a:lvl5pPr><a:lvl6pPr marL="2286000" algn="l" defTabSz="914400" rtl="0" eaLnBrk="1" latinLnBrk="0" hangingPunct="1"><a:defRPr sz="1800" kern="1200"><a:solidFill><a:schemeClr val="dk1"/></a:solidFill><a:latin typeface="Arial"/></a:defRPr></a:lvl6pPr><a:lvl7pPr marL="2743200" algn="l" defTabSz="914400" rtl="0" eaLnBrk="1" latinLnBrk="0" hangingPunct="1"><a:defRPr sz="1800" kern="1200"><a:solidFill><a:schemeClr val="dk1"/></a:solidFill><a:latin typeface="Arial"/></a:defRPr></a:lvl7pPr><a:lvl8pPr marL="3200400" algn="l" defTabSz="914400" rtl="0" eaLnBrk="1" latinLnBrk="0" hangingPunct="1"><a:defRPr sz="1800" kern="1200"><a:solidFill><a:schemeClr val="dk1"/></a:solidFill><a:latin typeface="Arial"/></a:defRPr></a:lvl8pPr><a:lvl9pPr marL="3657600" algn="l" defTabSz="914400" rtl="0" eaLnBrk="1" latinLnBrk="0" hangingPunct="1"><a:defRPr sz="1800" kern="1200"><a:solidFill><a:schemeClr val="dk1"/></a:solidFill><a:latin typeface="Arial"/></a:defRPr></a:lvl9pPr></a:lstStyle><a:p><a:pPr marL="0" marR="0" lvl="0" indent="0" algn="l" defTabSz="457200" rtl="0" eaLnBrk="1" fontAlgn="auto" latinLnBrk="0" hangingPunct="1"><a:lnSpc><a:spcPct val="90000"/></a:lnSpc><a:spcBef><a:spcPts val="0"/></a:spcBef><a:spcAft><a:spcPts val="600"/></a:spcAft><a:buClrTx/><a:buSzTx/><a:buFontTx/><a:buNone/><a:tabLst/><a:defRPr/></a:pPr><a:endParaRPr lang="en-GB" sz="1600" kern="1200" spc="-20" dirty="0"><a:solidFill><a:schemeClr val="tx1"><a:lumMod val="85000"/><a:lumOff val="15000"/></a:schemeClr></a:solidFill><a:latin typeface="+mj-lt"/><a:ea typeface="+mn-ea"/><a:cs typeface="+mn-cs"/></a:endParaRPr></a:p></a:txBody><a:tcPr marL="192000" marR="192000" anchor="ctr"><a:lnL w="19050" cap="flat" cmpd="sng" algn="ctr"><a:noFill/><a:prstDash val="solid"/><a:round/><a:headEnd type="none" w="med" len="med"/><a:tailEnd type="none" w="med" len="med"/></a:lnL><a:lnR w="12700" cmpd="sng"><a:noFill/></a:lnR><a:lnT w="57150" cap="flat" cmpd="sng" algn="ctr"><a:solidFill><a:schemeClr val="bg1"/></a:solidFill><a:prstDash val="solid"/><a:round/><a:headEnd type="none" w="med" len="med"/><a:tailEnd type="none" w="med" len="med"/></a:lnT><a:lnB w="12700" cmpd="sng"><a:noFill/></a:lnB><a:lnTlToBr w="12700" cmpd="sng"><a:noFill/><a:prstDash val="solid"/></a:lnTlToBr><a:lnBlToTr w="12700" cmpd="sng"><a:noFill/><a:prstDash val="solid"/></a:lnBlToTr><a:solidFill><a:schemeClr val="accent1"/></a:solidFill></a:tcPr></a:tc><a:extLst><a:ext uri="{0D108BD9-81ED-4DB2-BD59-A6C34878D82A}"><a16:rowId xmlns:a16="http://schemas.microsoft.com/office/drawing/2014/main" val="10003"/></a:ext></a:extLst></a:tr></a:tbl></a:graphicData></a:graphic></p:graphicFrame><p:sp><p:nvSpPr><p:cNvPr id="9" name="Text Placeholder 2"><a:extLst><a:ext uri="{FF2B5EF4-FFF2-40B4-BE49-F238E27FC236}"><a16:creationId xmlns:a16="http://schemas.microsoft.com/office/drawing/2014/main" id="{077E441D-7CFB-3297-A6BF-FF601C029EF0}"/></a:ext></a:extLst></p:cNvPr><p:cNvSpPr><a:spLocks noGrp="1"/></p:cNvSpPr><p:nvPr><p:ph type="body" idx="83" hasCustomPrompt="1"/></p:nvPr></p:nvSpPr><p:spPr><a:xfrm><a:off x="516005" y="1788689"/><a:ext cx="3442040" cy="553998"/></a:xfrm></p:spPr><p:txBody><a:bodyPr wrap="square" anchor="t" anchorCtr="0"><a:spAutoFit/></a:bodyPr><a:lstStyle><a:lvl1pPr marL="0" indent="0" algn="l"><a:lnSpc><a:spcPct val="100000"/></a:lnSpc><a:spcAft><a:spcPts val="0"/></a:spcAft><a:buNone/><a:defRPr sz="1800" b="1" spc="0" baseline="0"><a:solidFill><a:schemeClr val="tx2"/></a:solidFill></a:defRPr></a:lvl1pPr><a:lvl2pPr marL="457200" indent="0"><a:buNone/><a:defRPr sz="2000" b="1"/></a:lvl2pPr><a:lvl3pPr marL="914400" indent="0"><a:buNone/><a:defRPr sz="1800" b="1"/></a:lvl3pPr><a:lvl4pPr marL="1371600" indent="0"><a:buNone/><a:defRPr sz="1600" b="1"/></a:lvl4pPr><a:lvl5pPr marL="1828800" indent="0"><a:buNone/><a:defRPr sz="1600" b="1"/></a:lvl5pPr><a:lvl6pPr marL="2286000" indent="0"><a:buNone/><a:defRPr sz="1600" b="1"/></a:lvl6pPr><a:lvl7pPr marL="2743200" indent="0"><a:buNone/><a:defRPr sz="1600" b="1"/></a:lvl7pPr><a:lvl8pPr marL="3200400" indent="0"><a:buNone/><a:defRPr sz="1600" b="1"/></a:lvl8pPr><a:lvl9pPr marL="3657600" indent="0"><a:buNone/><a:defRPr sz="1600" b="1"/></a:lvl9pPr></a:lstStyle><a:p><a:pPr lvl="0"/><a:r><a:rPr lang="en-GB" dirty="0"/><a:t>Header </a:t></a:r></a:p><a:p><a:pPr lvl="0"/><a:r><a:rPr lang="en-GB" dirty="0"/><a:t>(second line)</a:t></a:r></a:p></p:txBody></p:sp><p:sp><p:nvSpPr><p:cNvPr id="11" name="Text Placeholder 2"><a:extLst><a:ext uri="{FF2B5EF4-FFF2-40B4-BE49-F238E27FC236}"><a16:creationId xmlns:a16="http://schemas.microsoft.com/office/drawing/2014/main" id="{BE233C79-95A7-E719-B761-6E33CDB71352}"/></a:ext></a:extLst></p:cNvPr><p:cNvSpPr><a:spLocks noGrp="1"/></p:cNvSpPr><p:nvPr><p:ph type="body" idx="84" hasCustomPrompt="1"/></p:nvPr></p:nvSpPr><p:spPr><a:xfrm><a:off x="4387813" y="1788689"/><a:ext cx="3442040" cy="553998"/></a:xfrm></p:spPr><p:txBody><a:bodyPr wrap="square" anchor="t" anchorCtr="0"><a:spAutoFit/></a:bodyPr><a:lstStyle><a:lvl1pPr marL="0" indent="0" algn="l"><a:lnSpc><a:spcPct val="100000"/></a:lnSpc><a:spcAft><a:spcPts val="0"/></a:spcAft><a:buNone/><a:defRPr sz="1800" b="1" spc="0" baseline="0"><a:solidFill><a:schemeClr val="bg1"/></a:solidFill></a:defRPr></a:lvl1pPr><a:lvl2pPr marL="457200" indent="0"><a:buNone/><a:defRPr sz="2000" b="1"/></a:lvl2pPr><a:lvl3pPr marL="914400" indent="0"><a:buNone/><a:defRPr sz="1800" b="1"/></a:lvl3pPr><a:lvl4pPr marL="1371600" indent="0"><a:buNone/><a:defRPr sz="1600" b="1"/></a:lvl4pPr><a:lvl5pPr marL="1828800" indent="0"><a:buNone/><a:defRPr sz="1600" b="1"/></a:lvl5pPr><a:lvl6pPr marL="2286000" indent="0"><a:buNone/><a:defRPr sz="1600" b="1"/></a:lvl6pPr><a:lvl7pPr marL="2743200" indent="0"><a:buNone/><a:defRPr sz="1600" b="1"/></a:lvl7pPr><a:lvl8pPr marL="3200400" indent="0"><a:buNone/><a:defRPr sz="1600" b="1"/></a:lvl8pPr><a:lvl9pPr marL="3657600" indent="0"><a:buNone/><a:defRPr sz="1600" b="1"/></a:lvl9pPr></a:lstStyle><a:p><a:pPr lvl="0"/><a:r><a:rPr lang="en-GB" dirty="0"/><a:t>Header </a:t></a:r></a:p><a:p><a:pPr lvl="0"/><a:r><a:rPr lang="en-GB" dirty="0"/><a:t>(second line)</a:t></a:r></a:p></p:txBody></p:sp><p:sp><p:nvSpPr><p:cNvPr id="12" name="Text Placeholder 2"><a:extLst><a:ext uri="{FF2B5EF4-FFF2-40B4-BE49-F238E27FC236}"><a16:creationId xmlns:a16="http://schemas.microsoft.com/office/drawing/2014/main" id="{F2D700D5-084A-09E0-F34B-97243ED019CB}"/></a:ext></a:extLst></p:cNvPr><p:cNvSpPr><a:spLocks noGrp="1"/></p:cNvSpPr><p:nvPr><p:ph type="body" idx="85" hasCustomPrompt="1"/></p:nvPr></p:nvSpPr><p:spPr><a:xfrm><a:off x="8210049" y="1788689"/><a:ext cx="3442040" cy="553998"/></a:xfrm></p:spPr><p:txBody><a:bodyPr wrap="square" anchor="t" anchorCtr="0"><a:spAutoFit/></a:bodyPr><a:lstStyle><a:lvl1pPr marL="0" indent="0" algn="l"><a:lnSpc><a:spcPct val="100000"/></a:lnSpc><a:spcAft><a:spcPts val="0"/></a:spcAft><a:buNone/><a:defRPr sz="1800" b="1" spc="0" baseline="0"><a:solidFill><a:schemeClr val="bg1"/></a:solidFill></a:defRPr></a:lvl1pPr><a:lvl2pPr marL="457200" indent="0"><a:buNone/><a:defRPr sz="2000" b="1"/></a:lvl2pPr><a:lvl3pPr marL="914400" indent="0"><a:buNone/><a:defRPr sz="1800" b="1"/></a:lvl3pPr><a:lvl4pPr marL="1371600" indent="0"><a:buNone/><a:defRPr sz="1600" b="1"/></a:lvl4pPr><a:lvl5pPr marL="1828800" indent="0"><a:buNone/><a:defRPr sz="1600" b="1"/></a:lvl5pPr><a:lvl6pPr marL="2286000" indent="0"><a:buNone/><a:defRPr sz="1600" b="1"/></a:lvl6pPr><a:lvl7pPr marL="2743200" indent="0"><a:buNone/><a:defRPr sz="1600" b="1"/></a:lvl7pPr><a:lvl8pPr marL="3200400" indent="0"><a:buNone/><a:defRPr sz="1600" b="1"/></a:lvl8pPr><a:lvl9pPr marL="3657600" indent="0"><a:buNone/><a:defRPr sz="1600" b="1"/></a:lvl9pPr></a:lstStyle><a:p><a:pPr lvl="0"/><a:r><a:rPr lang="en-GB" dirty="0"/><a:t>Header </a:t></a:r></a:p><a:p><a:pPr lvl="0"/><a:r><a:rPr lang="en-GB" dirty="0"/><a:t>(second line)</a:t></a:r></a:p></p:txBody></p:sp><p:sp><p:nvSpPr><p:cNvPr id="13" name="Text Placeholder 20"><a:extLst><a:ext uri="{FF2B5EF4-FFF2-40B4-BE49-F238E27FC236}"><a16:creationId xmlns:a16="http://schemas.microsoft.com/office/drawing/2014/main" id="{3AD58D75-459D-C811-56ED-DDE134BBFA81}"/></a:ext></a:extLst></p:cNvPr><p:cNvSpPr><a:spLocks noGrp="1"/></p:cNvSpPr><p:nvPr><p:ph type="body" idx="33"/></p:nvPr></p:nvSpPr><p:spPr><a:xfrm><a:off x="526687" y="2685340"/><a:ext cx="3431358" cy="1037574"/></a:xfrm></p:spPr><p:txBody><a:bodyPr/><a:lstStyle><a:lvl1pPr><a:defRPr/></a:lvl1pPr></a:lstStyle><a:p><a:pPr marL="0" indent="0"><a:buNone/></a:pPr><a:endParaRPr lang="en-GB" sz="1200" dirty="0"/></a:p></p:txBody></p:sp><p:sp><p:nvSpPr><p:cNvPr id="14" name="Text Placeholder 20"><a:extLst><a:ext uri="{FF2B5EF4-FFF2-40B4-BE49-F238E27FC236}"><a16:creationId xmlns:a16="http://schemas.microsoft.com/office/drawing/2014/main" id="{16EA9668-1883-956E-35AC-8879B37636C3}"/></a:ext></a:extLst></p:cNvPr><p:cNvSpPr><a:spLocks noGrp="1"/></p:cNvSpPr><p:nvPr><p:ph type="body" idx="86"/></p:nvPr></p:nvSpPr><p:spPr><a:xfrm><a:off x="4398495" y="2685340"/><a:ext cx="3431358" cy="1037574"/></a:xfrm></p:spPr><p:txBody><a:bodyPr/><a:lstStyle><a:lvl1pPr><a:defRPr><a:solidFill><a:schemeClr val="bg1"/></a:solidFill></a:defRPr></a:lvl1pPr></a:lstStyle><a:p><a:pPr marL="0" indent="0"><a:buNone/></a:pPr><a:endParaRPr lang="en-GB" sz="1200" dirty="0"/></a:p></p:txBody></p:sp><p:sp><p:nvSpPr><p:cNvPr id="15" name="Text Placeholder 20"><a:extLst><a:ext uri="{FF2B5EF4-FFF2-40B4-BE49-F238E27FC236}"><a16:creationId xmlns:a16="http://schemas.microsoft.com/office/drawing/2014/main" id="{32BEA1D1-8003-4D85-E292-D629608CA595}"/></a:ext></a:extLst></p:cNvPr><p:cNvSpPr><a:spLocks noGrp="1"/></p:cNvSpPr><p:nvPr><p:ph type="body" idx="87"/></p:nvPr></p:nvSpPr><p:spPr><a:xfrm><a:off x="8220731" y="2694047"/><a:ext cx="3431358" cy="1037574"/></a:xfrm></p:spPr><p:txBody><a:bodyPr/><a:lstStyle><a:lvl1pPr><a:defRPr><a:solidFill><a:schemeClr val="bg1"/></a:solidFill></a:defRPr></a:lvl1pPr></a:lstStyle><a:p><a:pPr marL="0" indent="0"><a:buNone/></a:pPr><a:endParaRPr lang="en-GB" sz="1200" dirty="0"/></a:p></p:txBody></p:sp><p:sp><p:nvSpPr><p:cNvPr id="16" name="Text Placeholder 20"><a:extLst><a:ext uri="{FF2B5EF4-FFF2-40B4-BE49-F238E27FC236}"><a16:creationId xmlns:a16="http://schemas.microsoft.com/office/drawing/2014/main" id="{2527BD06-BA96-F6B9-45C5-B2E4260A8FEC}"/></a:ext></a:extLst></p:cNvPr><p:cNvSpPr><a:spLocks noGrp="1"/></p:cNvSpPr><p:nvPr><p:ph type="body" idx="88"/></p:nvPr></p:nvSpPr><p:spPr><a:xfrm><a:off x="535394" y="4039524"/><a:ext cx="3431358" cy="1037574"/></a:xfrm></p:spPr><p:txBody><a:bodyPr/><a:lstStyle><a:lvl1pPr><a:defRPr/></a:lvl1pPr></a:lstStyle><a:p><a:pPr marL="0" indent="0"><a:buNone/></a:pPr><a:endParaRPr lang="en-GB" sz="1200" dirty="0"/></a:p></p:txBody></p:sp><p:sp><p:nvSpPr><p:cNvPr id="17" name="Text Placeholder 20"><a:extLst><a:ext uri="{FF2B5EF4-FFF2-40B4-BE49-F238E27FC236}"><a16:creationId xmlns:a16="http://schemas.microsoft.com/office/drawing/2014/main" id="{3B5004D5-D629-2DA3-C93D-D1623644530C}"/></a:ext></a:extLst></p:cNvPr><p:cNvSpPr><a:spLocks noGrp="1"/></p:cNvSpPr><p:nvPr><p:ph type="body" idx="89"/></p:nvPr></p:nvSpPr><p:spPr><a:xfrm><a:off x="4407202" y="4039524"/><a:ext cx="3431358" cy="1037574"/></a:xfrm></p:spPr><p:txBody><a:bodyPr/><a:lstStyle><a:lvl1pPr><a:defRPr><a:solidFill><a:schemeClr val="bg1"/></a:solidFill></a:defRPr></a:lvl1pPr></a:lstStyle><a:p><a:pPr marL="0" indent="0"><a:buNone/></a:pPr><a:endParaRPr lang="en-GB" sz="1200" dirty="0"/></a:p></p:txBody></p:sp><p:sp><p:nvSpPr><p:cNvPr id="18" name="Text Placeholder 20"><a:extLst><a:ext uri="{FF2B5EF4-FFF2-40B4-BE49-F238E27FC236}"><a16:creationId xmlns:a16="http://schemas.microsoft.com/office/drawing/2014/main" id="{153AE787-66DE-A5FE-1718-E036C7B2C8EF}"/></a:ext></a:extLst></p:cNvPr><p:cNvSpPr><a:spLocks noGrp="1"/></p:cNvSpPr><p:nvPr><p:ph type="body" idx="90"/></p:nvPr></p:nvSpPr><p:spPr><a:xfrm><a:off x="8229438" y="4048231"/><a:ext cx="3431358" cy="1037574"/></a:xfrm></p:spPr><p:txBody><a:bodyPr/><a:lstStyle><a:lvl1pPr><a:defRPr><a:solidFill><a:schemeClr val="bg1"/></a:solidFill></a:defRPr></a:lvl1pPr></a:lstStyle><a:p><a:pPr marL="0" indent="0"><a:buNone/></a:pPr><a:endParaRPr lang="en-GB" sz="1200" dirty="0"/></a:p></p:txBody></p:sp><p:sp><p:nvSpPr><p:cNvPr id="19" name="Text Placeholder 20"><a:extLst><a:ext uri="{FF2B5EF4-FFF2-40B4-BE49-F238E27FC236}"><a16:creationId xmlns:a16="http://schemas.microsoft.com/office/drawing/2014/main" id="{99358F69-B4AC-AA58-7407-515269710DB8}"/></a:ext></a:extLst></p:cNvPr><p:cNvSpPr><a:spLocks noGrp="1"/></p:cNvSpPr><p:nvPr><p:ph type="body" idx="91"/></p:nvPr></p:nvSpPr><p:spPr><a:xfrm><a:off x="535394" y="5437253"/><a:ext cx="3431358" cy="1037574"/></a:xfrm></p:spPr><p:txBody><a:bodyPr/><a:lstStyle><a:lvl1pPr><a:defRPr/></a:lvl1pPr></a:lstStyle><a:p><a:pPr marL="0" indent="0"><a:buNone/></a:pPr><a:endParaRPr lang="en-GB" sz="1200" dirty="0"/></a:p></p:txBody></p:sp><p:sp><p:nvSpPr><p:cNvPr id="20" name="Text Placeholder 20"><a:extLst><a:ext uri="{FF2B5EF4-FFF2-40B4-BE49-F238E27FC236}"><a16:creationId xmlns:a16="http://schemas.microsoft.com/office/drawing/2014/main" id="{EEB914C6-D1B8-76B4-B72F-BDBAA57ABA62}"/></a:ext></a:extLst></p:cNvPr><p:cNvSpPr><a:spLocks noGrp="1"/></p:cNvSpPr><p:nvPr><p:ph type="body" idx="92"/></p:nvPr></p:nvSpPr><p:spPr><a:xfrm><a:off x="4407202" y="5437253"/><a:ext cx="3431358" cy="1037574"/></a:xfrm></p:spPr><p:txBody><a:bodyPr/><a:lstStyle><a:lvl1pPr><a:defRPr><a:solidFill><a:schemeClr val="bg1"/></a:solidFill></a:defRPr></a:lvl1pPr></a:lstStyle><a:p><a:pPr marL="0" indent="0"><a:buNone/></a:pPr><a:endParaRPr lang="en-GB" sz="1200" dirty="0"/></a:p></p:txBody></p:sp><p:sp><p:nvSpPr><p:cNvPr id="21" name="Text Placeholder 20"><a:extLst><a:ext uri="{FF2B5EF4-FFF2-40B4-BE49-F238E27FC236}"><a16:creationId xmlns:a16="http://schemas.microsoft.com/office/drawing/2014/main" id="{3724EF1A-9342-DCF9-017D-605DE3CF44C8}"/></a:ext></a:extLst></p:cNvPr><p:cNvSpPr><a:spLocks noGrp="1"/></p:cNvSpPr><p:nvPr><p:ph type="body" idx="93"/></p:nvPr></p:nvSpPr><p:spPr><a:xfrm><a:off x="8229438" y="5445960"/><a:ext cx="3431358" cy="1037574"/></a:xfrm></p:spPr><p:txBody><a:bodyPr/><a:lstStyle><a:lvl1pPr><a:defRPr><a:solidFill><a:schemeClr val="bg1"/></a:solidFill></a:defRPr></a:lvl1pPr></a:lstStyle><a:p><a:pPr marL="0" indent="0"><a:buNone/></a:pPr><a:endParaRPr lang="en-GB" sz="1200" dirty="0"/></a:p></p:txBody></p:sp><p:sp><p:nvSpPr><p:cNvPr id="23" name="Title 3"><a:extLst><a:ext uri="{FF2B5EF4-FFF2-40B4-BE49-F238E27FC236}"><a16:creationId xmlns:a16="http://schemas.microsoft.com/office/drawing/2014/main" id="{341DAAA3-EA54-A96B-546A-51E7920E3267}"/></a:ext></a:extLst></p:cNvPr><p:cNvSpPr><a:spLocks noGrp="1"/></p:cNvSpPr><p:nvPr><p:ph type="title"/></p:nvPr></p:nvSpPr><p:spPr><a:xfrm><a:off x="327212" y="790573"/><a:ext cx="11537580" cy="512961"/></a:xfrm></p:spPr><p:txBody><a:bodyPr/><a:lstStyle><a:lvl1pPr><a:defRPr/></a:lvl1pPr></a:lstStyle><a:p><a:endParaRPr lang="en-GB" dirty="0"/></a:p></p:txBody></p:sp></p:spTree><p:extLst><p:ext uri="{BB962C8B-B14F-4D97-AF65-F5344CB8AC3E}"><p14:creationId xmlns:p14="http://schemas.microsoft.com/office/powerpoint/2010/main" val="4109622162"/></p:ext></p:extLst></p:cSld><p:clrMapOvr><a:masterClrMapping/></p:clrMapOvr></p:sldLayout>
+<p:sldLayout xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main"
+  xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships"
+  xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main" preserve="1" userDrawn="1">
+  <p:cSld name="What will happen next component">
+    <p:bg>
+      <p:bgPr>
+        <a:solidFill>
+          <a:schemeClr val="bg1" />
+        </a:solidFill>
+        <a:effectLst />
+      </p:bgPr>
+    </p:bg>
+    <p:spTree>
+      <p:nvGrpSpPr>
+        <p:cNvPr id="1" name="" />
+        <p:cNvGrpSpPr />
+        <p:nvPr />
+      </p:nvGrpSpPr>
+      <p:grpSpPr>
+        <a:xfrm>
+          <a:off x="0" y="0" />
+          <a:ext cx="0" cy="0" />
+          <a:chOff x="0" y="0" />
+          <a:chExt cx="0" cy="0" />
+        </a:xfrm>
+      </p:grpSpPr>
+      <p:sp>
+        <p:nvSpPr>
+          <p:cNvPr id="3" name="Slide Number Placeholder 2">
+            <a:extLst>
+              <a:ext uri="{FF2B5EF4-FFF2-40B4-BE49-F238E27FC236}">
+                <a16:creationId xmlns:a16="http://schemas.microsoft.com/office/drawing/2014/main"
+                  id="{7B13548D-5456-D7B6-AA99-2AC4EB49C4A2}" />
+              </a:ext>
+            </a:extLst>
+          </p:cNvPr>
+          <p:cNvSpPr>
+            <a:spLocks noGrp="1" />
+          </p:cNvSpPr>
+          <p:nvPr>
+            <p:ph type="sldNum" sz="quarter" idx="10" />
+          </p:nvPr>
+        </p:nvSpPr>
+        <p:spPr />
+        <p:txBody>
+          <a:bodyPr />
+          <a:lstStyle />
+          <a:p>
+            <a:fld id="{1A1A750F-FD42-4280-B238-1AD3A0FAB732}" type="slidenum">
+              <a:rPr lang="en-GB" smtClean="0" />
+              <a:pPr />
+              <a:t>‹#›</a:t>
+            </a:fld>
+            <a:endParaRPr lang="en-GB" dirty="0" />
+          </a:p>
+        </p:txBody>
+      </p:sp>
+      <p:graphicFrame>
+        <p:nvGraphicFramePr>
+          <p:cNvPr id="7" name="Content Placeholder 18">
+            <a:extLst>
+              <a:ext uri="{FF2B5EF4-FFF2-40B4-BE49-F238E27FC236}">
+                <a16:creationId xmlns:a16="http://schemas.microsoft.com/office/drawing/2014/main"
+                  id="{257749DA-EC4E-4B77-3BF4-B75072818AD9}" />
+              </a:ext>
+            </a:extLst>
+          </p:cNvPr>
+          <p:cNvGraphicFramePr>
+            <a:graphicFrameLocks />
+          </p:cNvGraphicFramePr>
+          <p:nvPr userDrawn="1">
+            <p:extLst>
+              <p:ext uri="{D42A27DB-BD31-4B8C-83A1-F6EECF244321}">
+                <p14:modId xmlns:p14="http://schemas.microsoft.com/office/powerpoint/2010/main"
+                  val="2325708609" />
+              </p:ext>
+            </p:extLst>
+          </p:nvPr>
+        </p:nvGraphicFramePr>
+        <p:xfrm>
+          <a:off x="334434" y="1628773" />
+          <a:ext cx="11523132" cy="4993719" />
+        </p:xfrm>
+        <a:graphic>
+          <a:graphicData uri="http://schemas.openxmlformats.org/drawingml/2006/table">
+            <a:tbl>
+              <a:tblPr />
+              <a:tblGrid>
+                <a:gridCol w="3841044">
+                  <a:extLst>
+                    <a:ext uri="{9D8B030D-6E8A-4147-A177-3AD203B41FA5}">
+                      <a16:colId xmlns:a16="http://schemas.microsoft.com/office/drawing/2014/main"
+                        val="20000" />
+                    </a:ext>
+                  </a:extLst>
+                </a:gridCol>
+                <a:gridCol w="3841044">
+                  <a:extLst>
+                    <a:ext uri="{9D8B030D-6E8A-4147-A177-3AD203B41FA5}">
+                      <a16:colId xmlns:a16="http://schemas.microsoft.com/office/drawing/2014/main"
+                        val="20002" />
+                    </a:ext>
+                  </a:extLst>
+                </a:gridCol>
+                <a:gridCol w="3841044">
+                  <a:extLst>
+                    <a:ext uri="{9D8B030D-6E8A-4147-A177-3AD203B41FA5}">
+                      <a16:colId xmlns:a16="http://schemas.microsoft.com/office/drawing/2014/main"
+                        val="20004" />
+                    </a:ext>
+                  </a:extLst>
+                </a:gridCol>
+              </a:tblGrid>
+              <a:tr h="874570">
+                <a:tc>
+                  <a:txBody>
+                    <a:bodyPr />
+                    <a:lstStyle />
+                    <a:p>
+                      <a:pPr algn="l">
+                        <a:lnSpc>
+                          <a:spcPct val="90000" />
+                        </a:lnSpc>
+                        <a:spcAft>
+                          <a:spcPts val="600" />
+                        </a:spcAft>
+                      </a:pPr>
+                      <a:endParaRPr lang="en-GB" sz="1600" b="1" spc="-20" dirty="0">
+                        <a:solidFill>
+                          <a:schemeClr val="bg1" />
+                        </a:solidFill>
+                        <a:latin typeface="Arial" />
+                      </a:endParaRPr>
+                    </a:p>
+                    <a:p>
+                      <a:pPr algn="l">
+                        <a:lnSpc>
+                          <a:spcPct val="90000" />
+                        </a:lnSpc>
+                        <a:spcAft>
+                          <a:spcPts val="600" />
+                        </a:spcAft>
+                      </a:pPr>
+                      <a:endParaRPr lang="en-GB" sz="1600" b="1" spc="-20" dirty="0">
+                        <a:solidFill>
+                          <a:schemeClr val="bg1" />
+                        </a:solidFill>
+                        <a:latin typeface="Arial" />
+                      </a:endParaRPr>
+                    </a:p>
+                  </a:txBody>
+                  <a:tcPr marL="192000" marR="192000" anchor="ctr">
+                    <a:lnL w="12700" cmpd="sng">
+                      <a:noFill />
+                    </a:lnL>
+                    <a:lnR w="19050" cap="flat" cmpd="sng" algn="ctr">
+                      <a:noFill />
+                      <a:prstDash val="solid" />
+                      <a:round />
+                      <a:headEnd type="none" w="med" len="med" />
+                      <a:tailEnd type="none" w="med" len="med" />
+                    </a:lnR>
+                    <a:lnT w="12700" cap="flat" cmpd="sng" algn="ctr">
+                      <a:solidFill>
+                        <a:srgbClr val="FFFFFF" />
+                      </a:solidFill>
+                      <a:prstDash val="solid" />
+                      <a:round />
+                      <a:headEnd type="none" w="med" len="med" />
+                      <a:tailEnd type="none" w="med" len="med" />
+                    </a:lnT>
+                    <a:lnB w="57150" cap="flat" cmpd="sng" algn="ctr">
+                      <a:solidFill>
+                        <a:schemeClr val="bg1" />
+                      </a:solidFill>
+                      <a:prstDash val="solid" />
+                      <a:round />
+                      <a:headEnd type="none" w="med" len="med" />
+                      <a:tailEnd type="none" w="med" len="med" />
+                    </a:lnB>
+                    <a:lnTlToBr w="12700" cmpd="sng">
+                      <a:noFill />
+                      <a:prstDash val="solid" />
+                    </a:lnTlToBr>
+                    <a:lnBlToTr w="12700" cmpd="sng">
+                      <a:noFill />
+                      <a:prstDash val="solid" />
+                    </a:lnBlToTr>
+                    <a:solidFill>
+                      <a:schemeClr val="bg1">
+                        <a:lumMod val="95000" />
+                      </a:schemeClr>
+                    </a:solidFill>
+                  </a:tcPr>
+                </a:tc>
+                <a:tc>
+                  <a:txBody>
+                    <a:bodyPr />
+                    <a:lstStyle />
+                    <a:p>
+                      <a:pPr marL="0" marR="0" lvl="0" indent="0" algn="l" defTabSz="457200" rtl="0"
+                        eaLnBrk="1" fontAlgn="auto" latinLnBrk="0" hangingPunct="1">
+                        <a:lnSpc>
+                          <a:spcPct val="90000" />
+                        </a:lnSpc>
+                        <a:spcBef>
+                          <a:spcPts val="0" />
+                        </a:spcBef>
+                        <a:spcAft>
+                          <a:spcPts val="600" />
+                        </a:spcAft>
+                        <a:buClrTx />
+                        <a:buSzTx />
+                        <a:buFontTx />
+                        <a:buNone />
+                        <a:tabLst />
+                        <a:defRPr />
+                      </a:pPr>
+                      <a:endParaRPr lang="en-GB" sz="1600" kern="1200" spc="-20">
+                        <a:solidFill>
+                          <a:schemeClr val="tx1">
+                            <a:lumMod val="85000" />
+                            <a:lumOff val="15000" />
+                          </a:schemeClr>
+                        </a:solidFill>
+                        <a:latin typeface="Arial" />
+                        <a:ea typeface="+mn-ea" />
+                        <a:cs typeface="+mn-cs" />
+                      </a:endParaRPr>
+                    </a:p>
+                  </a:txBody>
+                  <a:tcPr marL="192000" marR="192000" anchor="ctr">
+                    <a:lnL w="19050" cap="flat" cmpd="sng" algn="ctr">
+                      <a:noFill />
+                      <a:prstDash val="solid" />
+                      <a:round />
+                      <a:headEnd type="none" w="med" len="med" />
+                      <a:tailEnd type="none" w="med" len="med" />
+                    </a:lnL>
+                    <a:lnR w="19050" cap="flat" cmpd="sng" algn="ctr">
+                      <a:noFill />
+                      <a:prstDash val="solid" />
+                      <a:round />
+                      <a:headEnd type="none" w="med" len="med" />
+                      <a:tailEnd type="none" w="med" len="med" />
+                    </a:lnR>
+                    <a:lnT w="12700" cap="flat" cmpd="sng" algn="ctr">
+                      <a:solidFill>
+                        <a:srgbClr val="FFFFFF" />
+                      </a:solidFill>
+                      <a:prstDash val="solid" />
+                      <a:round />
+                      <a:headEnd type="none" w="med" len="med" />
+                      <a:tailEnd type="none" w="med" len="med" />
+                    </a:lnT>
+                    <a:lnB w="57150" cap="flat" cmpd="sng" algn="ctr">
+                      <a:solidFill>
+                        <a:schemeClr val="bg1" />
+                      </a:solidFill>
+                      <a:prstDash val="solid" />
+                      <a:round />
+                      <a:headEnd type="none" w="med" len="med" />
+                      <a:tailEnd type="none" w="med" len="med" />
+                    </a:lnB>
+                    <a:lnTlToBr w="12700" cmpd="sng">
+                      <a:noFill />
+                      <a:prstDash val="solid" />
+                    </a:lnTlToBr>
+                    <a:lnBlToTr w="12700" cmpd="sng">
+                      <a:noFill />
+                      <a:prstDash val="solid" />
+                    </a:lnBlToTr>
+                    <a:solidFill>
+                      <a:schemeClr val="tx1" />
+                    </a:solidFill>
+                  </a:tcPr>
+                </a:tc>
+                <a:tc>
+                  <a:txBody>
+                    <a:bodyPr />
+                    <a:lstStyle />
+                    <a:p>
+                      <a:pPr marL="0" marR="0" lvl="0" indent="0" algn="l" defTabSz="457200" rtl="0"
+                        eaLnBrk="1" fontAlgn="auto" latinLnBrk="0" hangingPunct="1">
+                        <a:lnSpc>
+                          <a:spcPct val="90000" />
+                        </a:lnSpc>
+                        <a:spcBef>
+                          <a:spcPts val="0" />
+                        </a:spcBef>
+                        <a:spcAft>
+                          <a:spcPts val="600" />
+                        </a:spcAft>
+                        <a:buClrTx />
+                        <a:buSzTx />
+                        <a:buFontTx />
+                        <a:buNone />
+                        <a:tabLst />
+                        <a:defRPr />
+                      </a:pPr>
+                      <a:endParaRPr lang="en-GB" sz="1600" kern="1200" spc="-20" dirty="0">
+                        <a:solidFill>
+                          <a:schemeClr val="tx1">
+                            <a:lumMod val="85000" />
+                            <a:lumOff val="15000" />
+                          </a:schemeClr>
+                        </a:solidFill>
+                        <a:latin typeface="Arial" />
+                        <a:ea typeface="+mn-ea" />
+                        <a:cs typeface="+mn-cs" />
+                      </a:endParaRPr>
+                    </a:p>
+                  </a:txBody>
+                  <a:tcPr marL="192000" marR="192000" anchor="ctr">
+                    <a:lnL w="19050" cap="flat" cmpd="sng" algn="ctr">
+                      <a:noFill />
+                      <a:prstDash val="solid" />
+                      <a:round />
+                      <a:headEnd type="none" w="med" len="med" />
+                      <a:tailEnd type="none" w="med" len="med" />
+                    </a:lnL>
+                    <a:lnR w="12700" cmpd="sng">
+                      <a:noFill />
+                    </a:lnR>
+                    <a:lnT w="12700" cap="flat" cmpd="sng" algn="ctr">
+                      <a:solidFill>
+                        <a:srgbClr val="FFFFFF" />
+                      </a:solidFill>
+                      <a:prstDash val="solid" />
+                      <a:round />
+                      <a:headEnd type="none" w="med" len="med" />
+                      <a:tailEnd type="none" w="med" len="med" />
+                    </a:lnT>
+                    <a:lnB w="57150" cap="flat" cmpd="sng" algn="ctr">
+                      <a:solidFill>
+                        <a:schemeClr val="bg1" />
+                      </a:solidFill>
+                      <a:prstDash val="solid" />
+                      <a:round />
+                      <a:headEnd type="none" w="med" len="med" />
+                      <a:tailEnd type="none" w="med" len="med" />
+                    </a:lnB>
+                    <a:lnTlToBr w="12700" cmpd="sng">
+                      <a:noFill />
+                      <a:prstDash val="solid" />
+                    </a:lnTlToBr>
+                    <a:lnBlToTr w="12700" cmpd="sng">
+                      <a:noFill />
+                      <a:prstDash val="solid" />
+                    </a:lnBlToTr>
+                    <a:solidFill>
+                      <a:schemeClr val="accent1" />
+                    </a:solidFill>
+                  </a:tcPr>
+                </a:tc>
+                <a:extLst>
+                  <a:ext uri="{0D108BD9-81ED-4DB2-BD59-A6C34878D82A}">
+                    <a16:rowId xmlns:a16="http://schemas.microsoft.com/office/drawing/2014/main"
+                      val="1441025099" />
+                  </a:ext>
+                </a:extLst>
+              </a:tr>
+              <a:tr h="1363263">
+                <a:tc>
+                  <a:txBody>
+                    <a:bodyPr />
+                    <a:lstStyle>
+                      <a:defPPr>
+                        <a:defRPr lang="en-US" />
+                      </a:defPPr>
+                      <a:lvl1pPr marL="0" algn="l" defTabSz="914400" rtl="0" eaLnBrk="1"
+                        latinLnBrk="0" hangingPunct="1">
+                        <a:defRPr sz="1800" kern="1200">
+                          <a:solidFill>
+                            <a:schemeClr val="dk1" />
+                          </a:solidFill>
+                          <a:latin typeface="Arial" />
+                        </a:defRPr>
+                      </a:lvl1pPr>
+                      <a:lvl2pPr marL="457200" algn="l" defTabSz="914400" rtl="0" eaLnBrk="1"
+                        latinLnBrk="0" hangingPunct="1">
+                        <a:defRPr sz="1800" kern="1200">
+                          <a:solidFill>
+                            <a:schemeClr val="dk1" />
+                          </a:solidFill>
+                          <a:latin typeface="Arial" />
+                        </a:defRPr>
+                      </a:lvl2pPr>
+                      <a:lvl3pPr marL="914400" algn="l" defTabSz="914400" rtl="0" eaLnBrk="1"
+                        latinLnBrk="0" hangingPunct="1">
+                        <a:defRPr sz="1800" kern="1200">
+                          <a:solidFill>
+                            <a:schemeClr val="dk1" />
+                          </a:solidFill>
+                          <a:latin typeface="Arial" />
+                        </a:defRPr>
+                      </a:lvl3pPr>
+                      <a:lvl4pPr marL="1371600" algn="l" defTabSz="914400" rtl="0" eaLnBrk="1"
+                        latinLnBrk="0" hangingPunct="1">
+                        <a:defRPr sz="1800" kern="1200">
+                          <a:solidFill>
+                            <a:schemeClr val="dk1" />
+                          </a:solidFill>
+                          <a:latin typeface="Arial" />
+                        </a:defRPr>
+                      </a:lvl4pPr>
+                      <a:lvl5pPr marL="1828800" algn="l" defTabSz="914400" rtl="0" eaLnBrk="1"
+                        latinLnBrk="0" hangingPunct="1">
+                        <a:defRPr sz="1800" kern="1200">
+                          <a:solidFill>
+                            <a:schemeClr val="dk1" />
+                          </a:solidFill>
+                          <a:latin typeface="Arial" />
+                        </a:defRPr>
+                      </a:lvl5pPr>
+                      <a:lvl6pPr marL="2286000" algn="l" defTabSz="914400" rtl="0" eaLnBrk="1"
+                        latinLnBrk="0" hangingPunct="1">
+                        <a:defRPr sz="1800" kern="1200">
+                          <a:solidFill>
+                            <a:schemeClr val="dk1" />
+                          </a:solidFill>
+                          <a:latin typeface="Arial" />
+                        </a:defRPr>
+                      </a:lvl6pPr>
+                      <a:lvl7pPr marL="2743200" algn="l" defTabSz="914400" rtl="0" eaLnBrk="1"
+                        latinLnBrk="0" hangingPunct="1">
+                        <a:defRPr sz="1800" kern="1200">
+                          <a:solidFill>
+                            <a:schemeClr val="dk1" />
+                          </a:solidFill>
+                          <a:latin typeface="Arial" />
+                        </a:defRPr>
+                      </a:lvl7pPr>
+                      <a:lvl8pPr marL="3200400" algn="l" defTabSz="914400" rtl="0" eaLnBrk="1"
+                        latinLnBrk="0" hangingPunct="1">
+                        <a:defRPr sz="1800" kern="1200">
+                          <a:solidFill>
+                            <a:schemeClr val="dk1" />
+                          </a:solidFill>
+                          <a:latin typeface="Arial" />
+                        </a:defRPr>
+                      </a:lvl8pPr>
+                      <a:lvl9pPr marL="3657600" algn="l" defTabSz="914400" rtl="0" eaLnBrk="1"
+                        latinLnBrk="0" hangingPunct="1">
+                        <a:defRPr sz="1800" kern="1200">
+                          <a:solidFill>
+                            <a:schemeClr val="dk1" />
+                          </a:solidFill>
+                          <a:latin typeface="Arial" />
+                        </a:defRPr>
+                      </a:lvl9pPr>
+                    </a:lstStyle>
+                    <a:p>
+                      <a:pPr algn="l">
+                        <a:lnSpc>
+                          <a:spcPct val="90000" />
+                        </a:lnSpc>
+                        <a:spcAft>
+                          <a:spcPts val="600" />
+                        </a:spcAft>
+                      </a:pPr>
+                      <a:endParaRPr lang="en-GB" sz="1600" b="1" spc="-20" dirty="0">
+                        <a:solidFill>
+                          <a:schemeClr val="bg1" />
+                        </a:solidFill>
+                        <a:latin typeface="Arial" />
+                      </a:endParaRPr>
+                    </a:p>
+                  </a:txBody>
+                  <a:tcPr marL="192000" marR="192000" anchor="ctr">
+                    <a:lnL w="12700" cmpd="sng">
+                      <a:noFill />
+                    </a:lnL>
+                    <a:lnR w="19050" cap="flat" cmpd="sng" algn="ctr">
+                      <a:noFill />
+                      <a:prstDash val="solid" />
+                      <a:round />
+                      <a:headEnd type="none" w="med" len="med" />
+                      <a:tailEnd type="none" w="med" len="med" />
+                    </a:lnR>
+                    <a:lnT w="57150" cap="flat" cmpd="sng" algn="ctr">
+                      <a:solidFill>
+                        <a:schemeClr val="bg1" />
+                      </a:solidFill>
+                      <a:prstDash val="solid" />
+                      <a:round />
+                      <a:headEnd type="none" w="med" len="med" />
+                      <a:tailEnd type="none" w="med" len="med" />
+                    </a:lnT>
+                    <a:lnB w="57150" cap="flat" cmpd="sng" algn="ctr">
+                      <a:solidFill>
+                        <a:schemeClr val="bg1" />
+                      </a:solidFill>
+                      <a:prstDash val="solid" />
+                      <a:round />
+                      <a:headEnd type="none" w="med" len="med" />
+                      <a:tailEnd type="none" w="med" len="med" />
+                    </a:lnB>
+                    <a:lnTlToBr w="12700" cmpd="sng">
+                      <a:noFill />
+                      <a:prstDash val="solid" />
+                    </a:lnTlToBr>
+                    <a:lnBlToTr w="12700" cmpd="sng">
+                      <a:noFill />
+                      <a:prstDash val="solid" />
+                    </a:lnBlToTr>
+                    <a:solidFill>
+                      <a:schemeClr val="bg1">
+                        <a:lumMod val="95000" />
+                      </a:schemeClr>
+                    </a:solidFill>
+                  </a:tcPr>
+                </a:tc>
+                <a:tc>
+                  <a:txBody>
+                    <a:bodyPr />
+                    <a:lstStyle>
+                      <a:defPPr>
+                        <a:defRPr lang="en-US" />
+                      </a:defPPr>
+                      <a:lvl1pPr marL="0" algn="l" defTabSz="914400" rtl="0" eaLnBrk="1"
+                        latinLnBrk="0" hangingPunct="1">
+                        <a:defRPr sz="1800" kern="1200">
+                          <a:solidFill>
+                            <a:schemeClr val="dk1" />
+                          </a:solidFill>
+                          <a:latin typeface="Arial" />
+                        </a:defRPr>
+                      </a:lvl1pPr>
+                      <a:lvl2pPr marL="457200" algn="l" defTabSz="914400" rtl="0" eaLnBrk="1"
+                        latinLnBrk="0" hangingPunct="1">
+                        <a:defRPr sz="1800" kern="1200">
+                          <a:solidFill>
+                            <a:schemeClr val="dk1" />
+                          </a:solidFill>
+                          <a:latin typeface="Arial" />
+                        </a:defRPr>
+                      </a:lvl2pPr>
+                      <a:lvl3pPr marL="914400" algn="l" defTabSz="914400" rtl="0" eaLnBrk="1"
+                        latinLnBrk="0" hangingPunct="1">
+                        <a:defRPr sz="1800" kern="1200">
+                          <a:solidFill>
+                            <a:schemeClr val="dk1" />
+                          </a:solidFill>
+                          <a:latin typeface="Arial" />
+                        </a:defRPr>
+                      </a:lvl3pPr>
+                      <a:lvl4pPr marL="1371600" algn="l" defTabSz="914400" rtl="0" eaLnBrk="1"
+                        latinLnBrk="0" hangingPunct="1">
+                        <a:defRPr sz="1800" kern="1200">
+                          <a:solidFill>
+                            <a:schemeClr val="dk1" />
+                          </a:solidFill>
+                          <a:latin typeface="Arial" />
+                        </a:defRPr>
+                      </a:lvl4pPr>
+                      <a:lvl5pPr marL="1828800" algn="l" defTabSz="914400" rtl="0" eaLnBrk="1"
+                        latinLnBrk="0" hangingPunct="1">
+                        <a:defRPr sz="1800" kern="1200">
+                          <a:solidFill>
+                            <a:schemeClr val="dk1" />
+                          </a:solidFill>
+                          <a:latin typeface="Arial" />
+                        </a:defRPr>
+                      </a:lvl5pPr>
+                      <a:lvl6pPr marL="2286000" algn="l" defTabSz="914400" rtl="0" eaLnBrk="1"
+                        latinLnBrk="0" hangingPunct="1">
+                        <a:defRPr sz="1800" kern="1200">
+                          <a:solidFill>
+                            <a:schemeClr val="dk1" />
+                          </a:solidFill>
+                          <a:latin typeface="Arial" />
+                        </a:defRPr>
+                      </a:lvl6pPr>
+                      <a:lvl7pPr marL="2743200" algn="l" defTabSz="914400" rtl="0" eaLnBrk="1"
+                        latinLnBrk="0" hangingPunct="1">
+                        <a:defRPr sz="1800" kern="1200">
+                          <a:solidFill>
+                            <a:schemeClr val="dk1" />
+                          </a:solidFill>
+                          <a:latin typeface="Arial" />
+                        </a:defRPr>
+                      </a:lvl7pPr>
+                      <a:lvl8pPr marL="3200400" algn="l" defTabSz="914400" rtl="0" eaLnBrk="1"
+                        latinLnBrk="0" hangingPunct="1">
+                        <a:defRPr sz="1800" kern="1200">
+                          <a:solidFill>
+                            <a:schemeClr val="dk1" />
+                          </a:solidFill>
+                          <a:latin typeface="Arial" />
+                        </a:defRPr>
+                      </a:lvl8pPr>
+                      <a:lvl9pPr marL="3657600" algn="l" defTabSz="914400" rtl="0" eaLnBrk="1"
+                        latinLnBrk="0" hangingPunct="1">
+                        <a:defRPr sz="1800" kern="1200">
+                          <a:solidFill>
+                            <a:schemeClr val="dk1" />
+                          </a:solidFill>
+                          <a:latin typeface="Arial" />
+                        </a:defRPr>
+                      </a:lvl9pPr>
+                    </a:lstStyle>
+                    <a:p>
+                      <a:pPr marL="0" marR="0" lvl="0" indent="0" algn="l" defTabSz="457200" rtl="0"
+                        eaLnBrk="1" fontAlgn="auto" latinLnBrk="0" hangingPunct="1">
+                        <a:lnSpc>
+                          <a:spcPct val="90000" />
+                        </a:lnSpc>
+                        <a:spcBef>
+                          <a:spcPts val="0" />
+                        </a:spcBef>
+                        <a:spcAft>
+                          <a:spcPts val="600" />
+                        </a:spcAft>
+                        <a:buClrTx />
+                        <a:buSzTx />
+                        <a:buFontTx />
+                        <a:buNone />
+                        <a:tabLst />
+                        <a:defRPr />
+                      </a:pPr>
+                      <a:endParaRPr lang="en-GB" sz="1600" kern="1200" spc="-20" dirty="0">
+                        <a:solidFill>
+                          <a:schemeClr val="tx1">
+                            <a:lumMod val="85000" />
+                            <a:lumOff val="15000" />
+                          </a:schemeClr>
+                        </a:solidFill>
+                        <a:latin typeface="Arial" />
+                        <a:ea typeface="+mn-ea" />
+                        <a:cs typeface="+mn-cs" />
+                      </a:endParaRPr>
+                    </a:p>
+                  </a:txBody>
+                  <a:tcPr marL="192000" marR="192000" anchor="ctr">
+                    <a:lnL w="19050" cap="flat" cmpd="sng" algn="ctr">
+                      <a:noFill />
+                      <a:prstDash val="solid" />
+                      <a:round />
+                      <a:headEnd type="none" w="med" len="med" />
+                      <a:tailEnd type="none" w="med" len="med" />
+                    </a:lnL>
+                    <a:lnR w="19050" cap="flat" cmpd="sng" algn="ctr">
+                      <a:noFill />
+                      <a:prstDash val="solid" />
+                      <a:round />
+                      <a:headEnd type="none" w="med" len="med" />
+                      <a:tailEnd type="none" w="med" len="med" />
+                    </a:lnR>
+                    <a:lnT w="57150" cap="flat" cmpd="sng" algn="ctr">
+                      <a:solidFill>
+                        <a:schemeClr val="bg1" />
+                      </a:solidFill>
+                      <a:prstDash val="solid" />
+                      <a:round />
+                      <a:headEnd type="none" w="med" len="med" />
+                      <a:tailEnd type="none" w="med" len="med" />
+                    </a:lnT>
+                    <a:lnB w="57150" cap="flat" cmpd="sng" algn="ctr">
+                      <a:solidFill>
+                        <a:schemeClr val="bg1" />
+                      </a:solidFill>
+                      <a:prstDash val="solid" />
+                      <a:round />
+                      <a:headEnd type="none" w="med" len="med" />
+                      <a:tailEnd type="none" w="med" len="med" />
+                    </a:lnB>
+                    <a:lnTlToBr w="12700" cmpd="sng">
+                      <a:noFill />
+                      <a:prstDash val="solid" />
+                    </a:lnTlToBr>
+                    <a:lnBlToTr w="12700" cmpd="sng">
+                      <a:noFill />
+                      <a:prstDash val="solid" />
+                    </a:lnBlToTr>
+                    <a:solidFill>
+                      <a:schemeClr val="tx1" />
+                    </a:solidFill>
+                  </a:tcPr>
+                </a:tc>
+                <a:tc>
+                  <a:txBody>
+                    <a:bodyPr />
+                    <a:lstStyle>
+                      <a:defPPr>
+                        <a:defRPr lang="en-US" />
+                      </a:defPPr>
+                      <a:lvl1pPr marL="0" algn="l" defTabSz="914400" rtl="0" eaLnBrk="1"
+                        latinLnBrk="0" hangingPunct="1">
+                        <a:defRPr sz="1800" kern="1200">
+                          <a:solidFill>
+                            <a:schemeClr val="dk1" />
+                          </a:solidFill>
+                          <a:latin typeface="Arial" />
+                        </a:defRPr>
+                      </a:lvl1pPr>
+                      <a:lvl2pPr marL="457200" algn="l" defTabSz="914400" rtl="0" eaLnBrk="1"
+                        latinLnBrk="0" hangingPunct="1">
+                        <a:defRPr sz="1800" kern="1200">
+                          <a:solidFill>
+                            <a:schemeClr val="dk1" />
+                          </a:solidFill>
+                          <a:latin typeface="Arial" />
+                        </a:defRPr>
+                      </a:lvl2pPr>
+                      <a:lvl3pPr marL="914400" algn="l" defTabSz="914400" rtl="0" eaLnBrk="1"
+                        latinLnBrk="0" hangingPunct="1">
+                        <a:defRPr sz="1800" kern="1200">
+                          <a:solidFill>
+                            <a:schemeClr val="dk1" />
+                          </a:solidFill>
+                          <a:latin typeface="Arial" />
+                        </a:defRPr>
+                      </a:lvl3pPr>
+                      <a:lvl4pPr marL="1371600" algn="l" defTabSz="914400" rtl="0" eaLnBrk="1"
+                        latinLnBrk="0" hangingPunct="1">
+                        <a:defRPr sz="1800" kern="1200">
+                          <a:solidFill>
+                            <a:schemeClr val="dk1" />
+                          </a:solidFill>
+                          <a:latin typeface="Arial" />
+                        </a:defRPr>
+                      </a:lvl4pPr>
+                      <a:lvl5pPr marL="1828800" algn="l" defTabSz="914400" rtl="0" eaLnBrk="1"
+                        latinLnBrk="0" hangingPunct="1">
+                        <a:defRPr sz="1800" kern="1200">
+                          <a:solidFill>
+                            <a:schemeClr val="dk1" />
+                          </a:solidFill>
+                          <a:latin typeface="Arial" />
+                        </a:defRPr>
+                      </a:lvl5pPr>
+                      <a:lvl6pPr marL="2286000" algn="l" defTabSz="914400" rtl="0" eaLnBrk="1"
+                        latinLnBrk="0" hangingPunct="1">
+                        <a:defRPr sz="1800" kern="1200">
+                          <a:solidFill>
+                            <a:schemeClr val="dk1" />
+                          </a:solidFill>
+                          <a:latin typeface="Arial" />
+                        </a:defRPr>
+                      </a:lvl6pPr>
+                      <a:lvl7pPr marL="2743200" algn="l" defTabSz="914400" rtl="0" eaLnBrk="1"
+                        latinLnBrk="0" hangingPunct="1">
+                        <a:defRPr sz="1800" kern="1200">
+                          <a:solidFill>
+                            <a:schemeClr val="dk1" />
+                          </a:solidFill>
+                          <a:latin typeface="Arial" />
+                        </a:defRPr>
+                      </a:lvl7pPr>
+                      <a:lvl8pPr marL="3200400" algn="l" defTabSz="914400" rtl="0" eaLnBrk="1"
+                        latinLnBrk="0" hangingPunct="1">
+                        <a:defRPr sz="1800" kern="1200">
+                          <a:solidFill>
+                            <a:schemeClr val="dk1" />
+                          </a:solidFill>
+                          <a:latin typeface="Arial" />
+                        </a:defRPr>
+                      </a:lvl8pPr>
+                      <a:lvl9pPr marL="3657600" algn="l" defTabSz="914400" rtl="0" eaLnBrk="1"
+                        latinLnBrk="0" hangingPunct="1">
+                        <a:defRPr sz="1800" kern="1200">
+                          <a:solidFill>
+                            <a:schemeClr val="dk1" />
+                          </a:solidFill>
+                          <a:latin typeface="Arial" />
+                        </a:defRPr>
+                      </a:lvl9pPr>
+                    </a:lstStyle>
+                    <a:p>
+                      <a:pPr marL="0" marR="0" lvl="0" indent="0" algn="l" defTabSz="457200" rtl="0"
+                        eaLnBrk="1" fontAlgn="auto" latinLnBrk="0" hangingPunct="1">
+                        <a:lnSpc>
+                          <a:spcPct val="90000" />
+                        </a:lnSpc>
+                        <a:spcBef>
+                          <a:spcPts val="0" />
+                        </a:spcBef>
+                        <a:spcAft>
+                          <a:spcPts val="600" />
+                        </a:spcAft>
+                        <a:buClrTx />
+                        <a:buSzTx />
+                        <a:buFontTx />
+                        <a:buNone />
+                        <a:tabLst />
+                        <a:defRPr />
+                      </a:pPr>
+                      <a:endParaRPr lang="en-GB" sz="1600" kern="1200" spc="-20" dirty="0">
+                        <a:solidFill>
+                          <a:schemeClr val="tx1">
+                            <a:lumMod val="85000" />
+                            <a:lumOff val="15000" />
+                          </a:schemeClr>
+                        </a:solidFill>
+                        <a:latin typeface="Arial" />
+                        <a:ea typeface="+mn-ea" />
+                        <a:cs typeface="+mn-cs" />
+                      </a:endParaRPr>
+                    </a:p>
+                  </a:txBody>
+                  <a:tcPr marL="192000" marR="192000" anchor="ctr">
+                    <a:lnL w="19050" cap="flat" cmpd="sng" algn="ctr">
+                      <a:noFill />
+                      <a:prstDash val="solid" />
+                      <a:round />
+                      <a:headEnd type="none" w="med" len="med" />
+                      <a:tailEnd type="none" w="med" len="med" />
+                    </a:lnL>
+                    <a:lnR w="12700" cmpd="sng">
+                      <a:noFill />
+                    </a:lnR>
+                    <a:lnT w="57150" cap="flat" cmpd="sng" algn="ctr">
+                      <a:solidFill>
+                        <a:schemeClr val="bg1" />
+                      </a:solidFill>
+                      <a:prstDash val="solid" />
+                      <a:round />
+                      <a:headEnd type="none" w="med" len="med" />
+                      <a:tailEnd type="none" w="med" len="med" />
+                    </a:lnT>
+                    <a:lnB w="57150" cap="flat" cmpd="sng" algn="ctr">
+                      <a:solidFill>
+                        <a:schemeClr val="bg1" />
+                      </a:solidFill>
+                      <a:prstDash val="solid" />
+                      <a:round />
+                      <a:headEnd type="none" w="med" len="med" />
+                      <a:tailEnd type="none" w="med" len="med" />
+                    </a:lnB>
+                    <a:lnTlToBr w="12700" cmpd="sng">
+                      <a:noFill />
+                      <a:prstDash val="solid" />
+                    </a:lnTlToBr>
+                    <a:lnBlToTr w="12700" cmpd="sng">
+                      <a:noFill />
+                      <a:prstDash val="solid" />
+                    </a:lnBlToTr>
+                    <a:solidFill>
+                      <a:schemeClr val="accent1" />
+                    </a:solidFill>
+                  </a:tcPr>
+                </a:tc>
+                <a:extLst>
+                  <a:ext uri="{0D108BD9-81ED-4DB2-BD59-A6C34878D82A}">
+                    <a16:rowId xmlns:a16="http://schemas.microsoft.com/office/drawing/2014/main"
+                      val="10001" />
+                  </a:ext>
+                </a:extLst>
+              </a:tr>
+              <a:tr h="1384663">
+                <a:tc>
+                  <a:txBody>
+                    <a:bodyPr />
+                    <a:lstStyle>
+                      <a:defPPr>
+                        <a:defRPr lang="en-US" />
+                      </a:defPPr>
+                      <a:lvl1pPr marL="0" algn="l" defTabSz="914400" rtl="0" eaLnBrk="1"
+                        latinLnBrk="0" hangingPunct="1">
+                        <a:defRPr sz="1800" kern="1200">
+                          <a:solidFill>
+                            <a:schemeClr val="dk1" />
+                          </a:solidFill>
+                          <a:latin typeface="Arial" />
+                        </a:defRPr>
+                      </a:lvl1pPr>
+                      <a:lvl2pPr marL="457200" algn="l" defTabSz="914400" rtl="0" eaLnBrk="1"
+                        latinLnBrk="0" hangingPunct="1">
+                        <a:defRPr sz="1800" kern="1200">
+                          <a:solidFill>
+                            <a:schemeClr val="dk1" />
+                          </a:solidFill>
+                          <a:latin typeface="Arial" />
+                        </a:defRPr>
+                      </a:lvl2pPr>
+                      <a:lvl3pPr marL="914400" algn="l" defTabSz="914400" rtl="0" eaLnBrk="1"
+                        latinLnBrk="0" hangingPunct="1">
+                        <a:defRPr sz="1800" kern="1200">
+                          <a:solidFill>
+                            <a:schemeClr val="dk1" />
+                          </a:solidFill>
+                          <a:latin typeface="Arial" />
+                        </a:defRPr>
+                      </a:lvl3pPr>
+                      <a:lvl4pPr marL="1371600" algn="l" defTabSz="914400" rtl="0" eaLnBrk="1"
+                        latinLnBrk="0" hangingPunct="1">
+                        <a:defRPr sz="1800" kern="1200">
+                          <a:solidFill>
+                            <a:schemeClr val="dk1" />
+                          </a:solidFill>
+                          <a:latin typeface="Arial" />
+                        </a:defRPr>
+                      </a:lvl4pPr>
+                      <a:lvl5pPr marL="1828800" algn="l" defTabSz="914400" rtl="0" eaLnBrk="1"
+                        latinLnBrk="0" hangingPunct="1">
+                        <a:defRPr sz="1800" kern="1200">
+                          <a:solidFill>
+                            <a:schemeClr val="dk1" />
+                          </a:solidFill>
+                          <a:latin typeface="Arial" />
+                        </a:defRPr>
+                      </a:lvl5pPr>
+                      <a:lvl6pPr marL="2286000" algn="l" defTabSz="914400" rtl="0" eaLnBrk="1"
+                        latinLnBrk="0" hangingPunct="1">
+                        <a:defRPr sz="1800" kern="1200">
+                          <a:solidFill>
+                            <a:schemeClr val="dk1" />
+                          </a:solidFill>
+                          <a:latin typeface="Arial" />
+                        </a:defRPr>
+                      </a:lvl6pPr>
+                      <a:lvl7pPr marL="2743200" algn="l" defTabSz="914400" rtl="0" eaLnBrk="1"
+                        latinLnBrk="0" hangingPunct="1">
+                        <a:defRPr sz="1800" kern="1200">
+                          <a:solidFill>
+                            <a:schemeClr val="dk1" />
+                          </a:solidFill>
+                          <a:latin typeface="Arial" />
+                        </a:defRPr>
+                      </a:lvl7pPr>
+                      <a:lvl8pPr marL="3200400" algn="l" defTabSz="914400" rtl="0" eaLnBrk="1"
+                        latinLnBrk="0" hangingPunct="1">
+                        <a:defRPr sz="1800" kern="1200">
+                          <a:solidFill>
+                            <a:schemeClr val="dk1" />
+                          </a:solidFill>
+                          <a:latin typeface="Arial" />
+                        </a:defRPr>
+                      </a:lvl8pPr>
+                      <a:lvl9pPr marL="3657600" algn="l" defTabSz="914400" rtl="0" eaLnBrk="1"
+                        latinLnBrk="0" hangingPunct="1">
+                        <a:defRPr sz="1800" kern="1200">
+                          <a:solidFill>
+                            <a:schemeClr val="dk1" />
+                          </a:solidFill>
+                          <a:latin typeface="Arial" />
+                        </a:defRPr>
+                      </a:lvl9pPr>
+                    </a:lstStyle>
+                    <a:p>
+                      <a:pPr algn="l">
+                        <a:lnSpc>
+                          <a:spcPct val="90000" />
+                        </a:lnSpc>
+                        <a:spcAft>
+                          <a:spcPts val="600" />
+                        </a:spcAft>
+                      </a:pPr>
+                      <a:endParaRPr lang="en-GB" sz="1600" spc="-20" dirty="0">
+                        <a:solidFill>
+                          <a:schemeClr val="bg1" />
+                        </a:solidFill>
+                        <a:latin typeface="Arial" />
+                      </a:endParaRPr>
+                    </a:p>
+                  </a:txBody>
+                  <a:tcPr marL="192000" marR="192000" anchor="ctr">
+                    <a:lnL w="12700" cmpd="sng">
+                      <a:noFill />
+                    </a:lnL>
+                    <a:lnR w="19050" cap="flat" cmpd="sng" algn="ctr">
+                      <a:noFill />
+                      <a:prstDash val="solid" />
+                      <a:round />
+                      <a:headEnd type="none" w="med" len="med" />
+                      <a:tailEnd type="none" w="med" len="med" />
+                    </a:lnR>
+                    <a:lnT w="57150" cap="flat" cmpd="sng" algn="ctr">
+                      <a:solidFill>
+                        <a:schemeClr val="bg1" />
+                      </a:solidFill>
+                      <a:prstDash val="solid" />
+                      <a:round />
+                      <a:headEnd type="none" w="med" len="med" />
+                      <a:tailEnd type="none" w="med" len="med" />
+                    </a:lnT>
+                    <a:lnB w="57150" cap="flat" cmpd="sng" algn="ctr">
+                      <a:solidFill>
+                        <a:schemeClr val="bg1" />
+                      </a:solidFill>
+                      <a:prstDash val="solid" />
+                      <a:round />
+                      <a:headEnd type="none" w="med" len="med" />
+                      <a:tailEnd type="none" w="med" len="med" />
+                    </a:lnB>
+                    <a:lnTlToBr w="12700" cmpd="sng">
+                      <a:noFill />
+                      <a:prstDash val="solid" />
+                    </a:lnTlToBr>
+                    <a:lnBlToTr w="12700" cmpd="sng">
+                      <a:noFill />
+                      <a:prstDash val="solid" />
+                    </a:lnBlToTr>
+                    <a:solidFill>
+                      <a:schemeClr val="bg1">
+                        <a:lumMod val="95000" />
+                      </a:schemeClr>
+                    </a:solidFill>
+                  </a:tcPr>
+                </a:tc>
+                <a:tc>
+                  <a:txBody>
+                    <a:bodyPr />
+                    <a:lstStyle>
+                      <a:defPPr>
+                        <a:defRPr lang="en-US" />
+                      </a:defPPr>
+                      <a:lvl1pPr marL="0" algn="l" defTabSz="914400" rtl="0" eaLnBrk="1"
+                        latinLnBrk="0" hangingPunct="1">
+                        <a:defRPr sz="1800" kern="1200">
+                          <a:solidFill>
+                            <a:schemeClr val="dk1" />
+                          </a:solidFill>
+                          <a:latin typeface="Arial" />
+                        </a:defRPr>
+                      </a:lvl1pPr>
+                      <a:lvl2pPr marL="457200" algn="l" defTabSz="914400" rtl="0" eaLnBrk="1"
+                        latinLnBrk="0" hangingPunct="1">
+                        <a:defRPr sz="1800" kern="1200">
+                          <a:solidFill>
+                            <a:schemeClr val="dk1" />
+                          </a:solidFill>
+                          <a:latin typeface="Arial" />
+                        </a:defRPr>
+                      </a:lvl2pPr>
+                      <a:lvl3pPr marL="914400" algn="l" defTabSz="914400" rtl="0" eaLnBrk="1"
+                        latinLnBrk="0" hangingPunct="1">
+                        <a:defRPr sz="1800" kern="1200">
+                          <a:solidFill>
+                            <a:schemeClr val="dk1" />
+                          </a:solidFill>
+                          <a:latin typeface="Arial" />
+                        </a:defRPr>
+                      </a:lvl3pPr>
+                      <a:lvl4pPr marL="1371600" algn="l" defTabSz="914400" rtl="0" eaLnBrk="1"
+                        latinLnBrk="0" hangingPunct="1">
+                        <a:defRPr sz="1800" kern="1200">
+                          <a:solidFill>
+                            <a:schemeClr val="dk1" />
+                          </a:solidFill>
+                          <a:latin typeface="Arial" />
+                        </a:defRPr>
+                      </a:lvl4pPr>
+                      <a:lvl5pPr marL="1828800" algn="l" defTabSz="914400" rtl="0" eaLnBrk="1"
+                        latinLnBrk="0" hangingPunct="1">
+                        <a:defRPr sz="1800" kern="1200">
+                          <a:solidFill>
+                            <a:schemeClr val="dk1" />
+                          </a:solidFill>
+                          <a:latin typeface="Arial" />
+                        </a:defRPr>
+                      </a:lvl5pPr>
+                      <a:lvl6pPr marL="2286000" algn="l" defTabSz="914400" rtl="0" eaLnBrk="1"
+                        latinLnBrk="0" hangingPunct="1">
+                        <a:defRPr sz="1800" kern="1200">
+                          <a:solidFill>
+                            <a:schemeClr val="dk1" />
+                          </a:solidFill>
+                          <a:latin typeface="Arial" />
+                        </a:defRPr>
+                      </a:lvl6pPr>
+                      <a:lvl7pPr marL="2743200" algn="l" defTabSz="914400" rtl="0" eaLnBrk="1"
+                        latinLnBrk="0" hangingPunct="1">
+                        <a:defRPr sz="1800" kern="1200">
+                          <a:solidFill>
+                            <a:schemeClr val="dk1" />
+                          </a:solidFill>
+                          <a:latin typeface="Arial" />
+                        </a:defRPr>
+                      </a:lvl7pPr>
+                      <a:lvl8pPr marL="3200400" algn="l" defTabSz="914400" rtl="0" eaLnBrk="1"
+                        latinLnBrk="0" hangingPunct="1">
+                        <a:defRPr sz="1800" kern="1200">
+                          <a:solidFill>
+                            <a:schemeClr val="dk1" />
+                          </a:solidFill>
+                          <a:latin typeface="Arial" />
+                        </a:defRPr>
+                      </a:lvl8pPr>
+                      <a:lvl9pPr marL="3657600" algn="l" defTabSz="914400" rtl="0" eaLnBrk="1"
+                        latinLnBrk="0" hangingPunct="1">
+                        <a:defRPr sz="1800" kern="1200">
+                          <a:solidFill>
+                            <a:schemeClr val="dk1" />
+                          </a:solidFill>
+                          <a:latin typeface="Arial" />
+                        </a:defRPr>
+                      </a:lvl9pPr>
+                    </a:lstStyle>
+                    <a:p>
+                      <a:pPr marL="0" marR="0" lvl="0" indent="0" algn="l" defTabSz="457200" rtl="0"
+                        eaLnBrk="1" fontAlgn="auto" latinLnBrk="0" hangingPunct="1">
+                        <a:lnSpc>
+                          <a:spcPct val="90000" />
+                        </a:lnSpc>
+                        <a:spcBef>
+                          <a:spcPts val="0" />
+                        </a:spcBef>
+                        <a:spcAft>
+                          <a:spcPts val="600" />
+                        </a:spcAft>
+                        <a:buClrTx />
+                        <a:buSzTx />
+                        <a:buFontTx />
+                        <a:buNone />
+                        <a:tabLst />
+                        <a:defRPr />
+                      </a:pPr>
+                      <a:endParaRPr lang="en-GB" sz="1600" kern="1200" spc="-20" dirty="0">
+                        <a:solidFill>
+                          <a:schemeClr val="tx1">
+                            <a:lumMod val="85000" />
+                            <a:lumOff val="15000" />
+                          </a:schemeClr>
+                        </a:solidFill>
+                        <a:latin typeface="Arial" />
+                        <a:ea typeface="+mn-ea" />
+                        <a:cs typeface="+mn-cs" />
+                      </a:endParaRPr>
+                    </a:p>
+                  </a:txBody>
+                  <a:tcPr marL="192000" marR="192000" anchor="ctr">
+                    <a:lnL w="19050" cap="flat" cmpd="sng" algn="ctr">
+                      <a:noFill />
+                      <a:prstDash val="solid" />
+                      <a:round />
+                      <a:headEnd type="none" w="med" len="med" />
+                      <a:tailEnd type="none" w="med" len="med" />
+                    </a:lnL>
+                    <a:lnR w="19050" cap="flat" cmpd="sng" algn="ctr">
+                      <a:noFill />
+                      <a:prstDash val="solid" />
+                      <a:round />
+                      <a:headEnd type="none" w="med" len="med" />
+                      <a:tailEnd type="none" w="med" len="med" />
+                    </a:lnR>
+                    <a:lnT w="57150" cap="flat" cmpd="sng" algn="ctr">
+                      <a:solidFill>
+                        <a:schemeClr val="bg1" />
+                      </a:solidFill>
+                      <a:prstDash val="solid" />
+                      <a:round />
+                      <a:headEnd type="none" w="med" len="med" />
+                      <a:tailEnd type="none" w="med" len="med" />
+                    </a:lnT>
+                    <a:lnB w="57150" cap="flat" cmpd="sng" algn="ctr">
+                      <a:solidFill>
+                        <a:schemeClr val="bg1" />
+                      </a:solidFill>
+                      <a:prstDash val="solid" />
+                      <a:round />
+                      <a:headEnd type="none" w="med" len="med" />
+                      <a:tailEnd type="none" w="med" len="med" />
+                    </a:lnB>
+                    <a:lnTlToBr w="12700" cmpd="sng">
+                      <a:noFill />
+                      <a:prstDash val="solid" />
+                    </a:lnTlToBr>
+                    <a:lnBlToTr w="12700" cmpd="sng">
+                      <a:noFill />
+                      <a:prstDash val="solid" />
+                    </a:lnBlToTr>
+                    <a:solidFill>
+                      <a:schemeClr val="tx1" />
+                    </a:solidFill>
+                  </a:tcPr>
+                </a:tc>
+                <a:tc>
+                  <a:txBody>
+                    <a:bodyPr />
+                    <a:lstStyle>
+                      <a:defPPr>
+                        <a:defRPr lang="en-US" />
+                      </a:defPPr>
+                      <a:lvl1pPr marL="0" algn="l" defTabSz="914400" rtl="0" eaLnBrk="1"
+                        latinLnBrk="0" hangingPunct="1">
+                        <a:defRPr sz="1800" kern="1200">
+                          <a:solidFill>
+                            <a:schemeClr val="dk1" />
+                          </a:solidFill>
+                          <a:latin typeface="Arial" />
+                        </a:defRPr>
+                      </a:lvl1pPr>
+                      <a:lvl2pPr marL="457200" algn="l" defTabSz="914400" rtl="0" eaLnBrk="1"
+                        latinLnBrk="0" hangingPunct="1">
+                        <a:defRPr sz="1800" kern="1200">
+                          <a:solidFill>
+                            <a:schemeClr val="dk1" />
+                          </a:solidFill>
+                          <a:latin typeface="Arial" />
+                        </a:defRPr>
+                      </a:lvl2pPr>
+                      <a:lvl3pPr marL="914400" algn="l" defTabSz="914400" rtl="0" eaLnBrk="1"
+                        latinLnBrk="0" hangingPunct="1">
+                        <a:defRPr sz="1800" kern="1200">
+                          <a:solidFill>
+                            <a:schemeClr val="dk1" />
+                          </a:solidFill>
+                          <a:latin typeface="Arial" />
+                        </a:defRPr>
+                      </a:lvl3pPr>
+                      <a:lvl4pPr marL="1371600" algn="l" defTabSz="914400" rtl="0" eaLnBrk="1"
+                        latinLnBrk="0" hangingPunct="1">
+                        <a:defRPr sz="1800" kern="1200">
+                          <a:solidFill>
+                            <a:schemeClr val="dk1" />
+                          </a:solidFill>
+                          <a:latin typeface="Arial" />
+                        </a:defRPr>
+                      </a:lvl4pPr>
+                      <a:lvl5pPr marL="1828800" algn="l" defTabSz="914400" rtl="0" eaLnBrk="1"
+                        latinLnBrk="0" hangingPunct="1">
+                        <a:defRPr sz="1800" kern="1200">
+                          <a:solidFill>
+                            <a:schemeClr val="dk1" />
+                          </a:solidFill>
+                          <a:latin typeface="Arial" />
+                        </a:defRPr>
+                      </a:lvl5pPr>
+                      <a:lvl6pPr marL="2286000" algn="l" defTabSz="914400" rtl="0" eaLnBrk="1"
+                        latinLnBrk="0" hangingPunct="1">
+                        <a:defRPr sz="1800" kern="1200">
+                          <a:solidFill>
+                            <a:schemeClr val="dk1" />
+                          </a:solidFill>
+                          <a:latin typeface="Arial" />
+                        </a:defRPr>
+                      </a:lvl6pPr>
+                      <a:lvl7pPr marL="2743200" algn="l" defTabSz="914400" rtl="0" eaLnBrk="1"
+                        latinLnBrk="0" hangingPunct="1">
+                        <a:defRPr sz="1800" kern="1200">
+                          <a:solidFill>
+                            <a:schemeClr val="dk1" />
+                          </a:solidFill>
+                          <a:latin typeface="Arial" />
+                        </a:defRPr>
+                      </a:lvl7pPr>
+                      <a:lvl8pPr marL="3200400" algn="l" defTabSz="914400" rtl="0" eaLnBrk="1"
+                        latinLnBrk="0" hangingPunct="1">
+                        <a:defRPr sz="1800" kern="1200">
+                          <a:solidFill>
+                            <a:schemeClr val="dk1" />
+                          </a:solidFill>
+                          <a:latin typeface="Arial" />
+                        </a:defRPr>
+                      </a:lvl8pPr>
+                      <a:lvl9pPr marL="3657600" algn="l" defTabSz="914400" rtl="0" eaLnBrk="1"
+                        latinLnBrk="0" hangingPunct="1">
+                        <a:defRPr sz="1800" kern="1200">
+                          <a:solidFill>
+                            <a:schemeClr val="dk1" />
+                          </a:solidFill>
+                          <a:latin typeface="Arial" />
+                        </a:defRPr>
+                      </a:lvl9pPr>
+                    </a:lstStyle>
+                    <a:p>
+                      <a:pPr marL="0" marR="0" lvl="0" indent="0" algn="l" defTabSz="457200" rtl="0"
+                        eaLnBrk="1" fontAlgn="auto" latinLnBrk="0" hangingPunct="1">
+                        <a:lnSpc>
+                          <a:spcPct val="90000" />
+                        </a:lnSpc>
+                        <a:spcBef>
+                          <a:spcPts val="0" />
+                        </a:spcBef>
+                        <a:spcAft>
+                          <a:spcPts val="600" />
+                        </a:spcAft>
+                        <a:buClrTx />
+                        <a:buSzTx />
+                        <a:buFontTx />
+                        <a:buNone />
+                        <a:tabLst />
+                        <a:defRPr />
+                      </a:pPr>
+                      <a:endParaRPr lang="en-GB" sz="1600" kern="1200" spc="-20" dirty="0">
+                        <a:solidFill>
+                          <a:schemeClr val="tx1">
+                            <a:lumMod val="85000" />
+                            <a:lumOff val="15000" />
+                          </a:schemeClr>
+                        </a:solidFill>
+                        <a:latin typeface="Arial" />
+                        <a:ea typeface="+mn-ea" />
+                        <a:cs typeface="+mn-cs" />
+                      </a:endParaRPr>
+                    </a:p>
+                  </a:txBody>
+                  <a:tcPr marL="192000" marR="192000" anchor="ctr">
+                    <a:lnL w="19050" cap="flat" cmpd="sng" algn="ctr">
+                      <a:noFill />
+                      <a:prstDash val="solid" />
+                      <a:round />
+                      <a:headEnd type="none" w="med" len="med" />
+                      <a:tailEnd type="none" w="med" len="med" />
+                    </a:lnL>
+                    <a:lnR w="12700" cmpd="sng">
+                      <a:noFill />
+                    </a:lnR>
+                    <a:lnT w="57150" cap="flat" cmpd="sng" algn="ctr">
+                      <a:solidFill>
+                        <a:schemeClr val="bg1" />
+                      </a:solidFill>
+                      <a:prstDash val="solid" />
+                      <a:round />
+                      <a:headEnd type="none" w="med" len="med" />
+                      <a:tailEnd type="none" w="med" len="med" />
+                    </a:lnT>
+                    <a:lnB w="57150" cap="flat" cmpd="sng" algn="ctr">
+                      <a:solidFill>
+                        <a:schemeClr val="bg1" />
+                      </a:solidFill>
+                      <a:prstDash val="solid" />
+                      <a:round />
+                      <a:headEnd type="none" w="med" len="med" />
+                      <a:tailEnd type="none" w="med" len="med" />
+                    </a:lnB>
+                    <a:lnTlToBr w="12700" cmpd="sng">
+                      <a:noFill />
+                      <a:prstDash val="solid" />
+                    </a:lnTlToBr>
+                    <a:lnBlToTr w="12700" cmpd="sng">
+                      <a:noFill />
+                      <a:prstDash val="solid" />
+                    </a:lnBlToTr>
+                    <a:solidFill>
+                      <a:schemeClr val="accent1" />
+                    </a:solidFill>
+                  </a:tcPr>
+                </a:tc>
+                <a:extLst>
+                  <a:ext uri="{0D108BD9-81ED-4DB2-BD59-A6C34878D82A}">
+                    <a16:rowId xmlns:a16="http://schemas.microsoft.com/office/drawing/2014/main"
+                      val="10002" />
+                  </a:ext>
+                </a:extLst>
+              </a:tr>
+              <a:tr h="1371223">
+                <a:tc>
+                  <a:txBody>
+                    <a:bodyPr />
+                    <a:lstStyle>
+                      <a:defPPr>
+                        <a:defRPr lang="en-US" />
+                      </a:defPPr>
+                      <a:lvl1pPr marL="0" algn="l" defTabSz="914400" rtl="0" eaLnBrk="1"
+                        latinLnBrk="0" hangingPunct="1">
+                        <a:defRPr sz="1800" kern="1200">
+                          <a:solidFill>
+                            <a:schemeClr val="dk1" />
+                          </a:solidFill>
+                          <a:latin typeface="Arial" />
+                        </a:defRPr>
+                      </a:lvl1pPr>
+                      <a:lvl2pPr marL="457200" algn="l" defTabSz="914400" rtl="0" eaLnBrk="1"
+                        latinLnBrk="0" hangingPunct="1">
+                        <a:defRPr sz="1800" kern="1200">
+                          <a:solidFill>
+                            <a:schemeClr val="dk1" />
+                          </a:solidFill>
+                          <a:latin typeface="Arial" />
+                        </a:defRPr>
+                      </a:lvl2pPr>
+                      <a:lvl3pPr marL="914400" algn="l" defTabSz="914400" rtl="0" eaLnBrk="1"
+                        latinLnBrk="0" hangingPunct="1">
+                        <a:defRPr sz="1800" kern="1200">
+                          <a:solidFill>
+                            <a:schemeClr val="dk1" />
+                          </a:solidFill>
+                          <a:latin typeface="Arial" />
+                        </a:defRPr>
+                      </a:lvl3pPr>
+                      <a:lvl4pPr marL="1371600" algn="l" defTabSz="914400" rtl="0" eaLnBrk="1"
+                        latinLnBrk="0" hangingPunct="1">
+                        <a:defRPr sz="1800" kern="1200">
+                          <a:solidFill>
+                            <a:schemeClr val="dk1" />
+                          </a:solidFill>
+                          <a:latin typeface="Arial" />
+                        </a:defRPr>
+                      </a:lvl4pPr>
+                      <a:lvl5pPr marL="1828800" algn="l" defTabSz="914400" rtl="0" eaLnBrk="1"
+                        latinLnBrk="0" hangingPunct="1">
+                        <a:defRPr sz="1800" kern="1200">
+                          <a:solidFill>
+                            <a:schemeClr val="dk1" />
+                          </a:solidFill>
+                          <a:latin typeface="Arial" />
+                        </a:defRPr>
+                      </a:lvl5pPr>
+                      <a:lvl6pPr marL="2286000" algn="l" defTabSz="914400" rtl="0" eaLnBrk="1"
+                        latinLnBrk="0" hangingPunct="1">
+                        <a:defRPr sz="1800" kern="1200">
+                          <a:solidFill>
+                            <a:schemeClr val="dk1" />
+                          </a:solidFill>
+                          <a:latin typeface="Arial" />
+                        </a:defRPr>
+                      </a:lvl6pPr>
+                      <a:lvl7pPr marL="2743200" algn="l" defTabSz="914400" rtl="0" eaLnBrk="1"
+                        latinLnBrk="0" hangingPunct="1">
+                        <a:defRPr sz="1800" kern="1200">
+                          <a:solidFill>
+                            <a:schemeClr val="dk1" />
+                          </a:solidFill>
+                          <a:latin typeface="Arial" />
+                        </a:defRPr>
+                      </a:lvl7pPr>
+                      <a:lvl8pPr marL="3200400" algn="l" defTabSz="914400" rtl="0" eaLnBrk="1"
+                        latinLnBrk="0" hangingPunct="1">
+                        <a:defRPr sz="1800" kern="1200">
+                          <a:solidFill>
+                            <a:schemeClr val="dk1" />
+                          </a:solidFill>
+                          <a:latin typeface="Arial" />
+                        </a:defRPr>
+                      </a:lvl8pPr>
+                      <a:lvl9pPr marL="3657600" algn="l" defTabSz="914400" rtl="0" eaLnBrk="1"
+                        latinLnBrk="0" hangingPunct="1">
+                        <a:defRPr sz="1800" kern="1200">
+                          <a:solidFill>
+                            <a:schemeClr val="dk1" />
+                          </a:solidFill>
+                          <a:latin typeface="Arial" />
+                        </a:defRPr>
+                      </a:lvl9pPr>
+                    </a:lstStyle>
+                    <a:p>
+                      <a:pPr algn="l">
+                        <a:lnSpc>
+                          <a:spcPct val="90000" />
+                        </a:lnSpc>
+                        <a:spcAft>
+                          <a:spcPts val="600" />
+                        </a:spcAft>
+                      </a:pPr>
+                      <a:endParaRPr lang="en-GB" sz="1600" spc="-20" dirty="0">
+                        <a:solidFill>
+                          <a:schemeClr val="bg1" />
+                        </a:solidFill>
+                        <a:latin typeface="+mj-lt" />
+                      </a:endParaRPr>
+                    </a:p>
+                  </a:txBody>
+                  <a:tcPr marL="192000" marR="192000" anchor="ctr">
+                    <a:lnL w="12700" cmpd="sng">
+                      <a:noFill />
+                    </a:lnL>
+                    <a:lnR w="19050" cap="flat" cmpd="sng" algn="ctr">
+                      <a:noFill />
+                      <a:prstDash val="solid" />
+                      <a:round />
+                      <a:headEnd type="none" w="med" len="med" />
+                      <a:tailEnd type="none" w="med" len="med" />
+                    </a:lnR>
+                    <a:lnT w="57150" cap="flat" cmpd="sng" algn="ctr">
+                      <a:solidFill>
+                        <a:schemeClr val="bg1" />
+                      </a:solidFill>
+                      <a:prstDash val="solid" />
+                      <a:round />
+                      <a:headEnd type="none" w="med" len="med" />
+                      <a:tailEnd type="none" w="med" len="med" />
+                    </a:lnT>
+                    <a:lnB w="12700" cmpd="sng">
+                      <a:noFill />
+                    </a:lnB>
+                    <a:lnTlToBr w="12700" cmpd="sng">
+                      <a:noFill />
+                      <a:prstDash val="solid" />
+                    </a:lnTlToBr>
+                    <a:lnBlToTr w="12700" cmpd="sng">
+                      <a:noFill />
+                      <a:prstDash val="solid" />
+                    </a:lnBlToTr>
+                    <a:solidFill>
+                      <a:schemeClr val="bg1">
+                        <a:lumMod val="95000" />
+                      </a:schemeClr>
+                    </a:solidFill>
+                  </a:tcPr>
+                </a:tc>
+                <a:tc>
+                  <a:txBody>
+                    <a:bodyPr />
+                    <a:lstStyle />
+                    <a:p>
+                      <a:endParaRPr lang="en-GB" sz="1600">
+                        <a:latin typeface="+mj-lt" />
+                      </a:endParaRPr>
+                    </a:p>
+                  </a:txBody>
+                  <a:tcPr marL="192000" marR="192000" anchor="ctr">
+                    <a:lnL w="19050" cap="flat" cmpd="sng" algn="ctr">
+                      <a:noFill />
+                      <a:prstDash val="solid" />
+                      <a:round />
+                      <a:headEnd type="none" w="med" len="med" />
+                      <a:tailEnd type="none" w="med" len="med" />
+                    </a:lnL>
+                    <a:lnR w="19050" cap="flat" cmpd="sng" algn="ctr">
+                      <a:noFill />
+                      <a:prstDash val="solid" />
+                      <a:round />
+                      <a:headEnd type="none" w="med" len="med" />
+                      <a:tailEnd type="none" w="med" len="med" />
+                    </a:lnR>
+                    <a:lnT w="57150" cap="flat" cmpd="sng" algn="ctr">
+                      <a:solidFill>
+                        <a:schemeClr val="bg1" />
+                      </a:solidFill>
+                      <a:prstDash val="solid" />
+                      <a:round />
+                      <a:headEnd type="none" w="med" len="med" />
+                      <a:tailEnd type="none" w="med" len="med" />
+                    </a:lnT>
+                    <a:lnB w="12700" cmpd="sng">
+                      <a:noFill />
+                    </a:lnB>
+                    <a:lnTlToBr w="12700" cmpd="sng">
+                      <a:noFill />
+                      <a:prstDash val="solid" />
+                    </a:lnTlToBr>
+                    <a:lnBlToTr w="12700" cmpd="sng">
+                      <a:noFill />
+                      <a:prstDash val="solid" />
+                    </a:lnBlToTr>
+                    <a:solidFill>
+                      <a:schemeClr val="tx1" />
+                    </a:solidFill>
+                  </a:tcPr>
+                </a:tc>
+                <a:tc>
+                  <a:txBody>
+                    <a:bodyPr />
+                    <a:lstStyle>
+                      <a:defPPr>
+                        <a:defRPr lang="en-US" />
+                      </a:defPPr>
+                      <a:lvl1pPr marL="0" algn="l" defTabSz="914400" rtl="0" eaLnBrk="1"
+                        latinLnBrk="0" hangingPunct="1">
+                        <a:defRPr sz="1800" kern="1200">
+                          <a:solidFill>
+                            <a:schemeClr val="dk1" />
+                          </a:solidFill>
+                          <a:latin typeface="Arial" />
+                        </a:defRPr>
+                      </a:lvl1pPr>
+                      <a:lvl2pPr marL="457200" algn="l" defTabSz="914400" rtl="0" eaLnBrk="1"
+                        latinLnBrk="0" hangingPunct="1">
+                        <a:defRPr sz="1800" kern="1200">
+                          <a:solidFill>
+                            <a:schemeClr val="dk1" />
+                          </a:solidFill>
+                          <a:latin typeface="Arial" />
+                        </a:defRPr>
+                      </a:lvl2pPr>
+                      <a:lvl3pPr marL="914400" algn="l" defTabSz="914400" rtl="0" eaLnBrk="1"
+                        latinLnBrk="0" hangingPunct="1">
+                        <a:defRPr sz="1800" kern="1200">
+                          <a:solidFill>
+                            <a:schemeClr val="dk1" />
+                          </a:solidFill>
+                          <a:latin typeface="Arial" />
+                        </a:defRPr>
+                      </a:lvl3pPr>
+                      <a:lvl4pPr marL="1371600" algn="l" defTabSz="914400" rtl="0" eaLnBrk="1"
+                        latinLnBrk="0" hangingPunct="1">
+                        <a:defRPr sz="1800" kern="1200">
+                          <a:solidFill>
+                            <a:schemeClr val="dk1" />
+                          </a:solidFill>
+                          <a:latin typeface="Arial" />
+                        </a:defRPr>
+                      </a:lvl4pPr>
+                      <a:lvl5pPr marL="1828800" algn="l" defTabSz="914400" rtl="0" eaLnBrk="1"
+                        latinLnBrk="0" hangingPunct="1">
+                        <a:defRPr sz="1800" kern="1200">
+                          <a:solidFill>
+                            <a:schemeClr val="dk1" />
+                          </a:solidFill>
+                          <a:latin typeface="Arial" />
+                        </a:defRPr>
+                      </a:lvl5pPr>
+                      <a:lvl6pPr marL="2286000" algn="l" defTabSz="914400" rtl="0" eaLnBrk="1"
+                        latinLnBrk="0" hangingPunct="1">
+                        <a:defRPr sz="1800" kern="1200">
+                          <a:solidFill>
+                            <a:schemeClr val="dk1" />
+                          </a:solidFill>
+                          <a:latin typeface="Arial" />
+                        </a:defRPr>
+                      </a:lvl6pPr>
+                      <a:lvl7pPr marL="2743200" algn="l" defTabSz="914400" rtl="0" eaLnBrk="1"
+                        latinLnBrk="0" hangingPunct="1">
+                        <a:defRPr sz="1800" kern="1200">
+                          <a:solidFill>
+                            <a:schemeClr val="dk1" />
+                          </a:solidFill>
+                          <a:latin typeface="Arial" />
+                        </a:defRPr>
+                      </a:lvl7pPr>
+                      <a:lvl8pPr marL="3200400" algn="l" defTabSz="914400" rtl="0" eaLnBrk="1"
+                        latinLnBrk="0" hangingPunct="1">
+                        <a:defRPr sz="1800" kern="1200">
+                          <a:solidFill>
+                            <a:schemeClr val="dk1" />
+                          </a:solidFill>
+                          <a:latin typeface="Arial" />
+                        </a:defRPr>
+                      </a:lvl8pPr>
+                      <a:lvl9pPr marL="3657600" algn="l" defTabSz="914400" rtl="0" eaLnBrk="1"
+                        latinLnBrk="0" hangingPunct="1">
+                        <a:defRPr sz="1800" kern="1200">
+                          <a:solidFill>
+                            <a:schemeClr val="dk1" />
+                          </a:solidFill>
+                          <a:latin typeface="Arial" />
+                        </a:defRPr>
+                      </a:lvl9pPr>
+                    </a:lstStyle>
+                    <a:p>
+                      <a:pPr marL="0" marR="0" lvl="0" indent="0" algn="l" defTabSz="457200" rtl="0"
+                        eaLnBrk="1" fontAlgn="auto" latinLnBrk="0" hangingPunct="1">
+                        <a:lnSpc>
+                          <a:spcPct val="90000" />
+                        </a:lnSpc>
+                        <a:spcBef>
+                          <a:spcPts val="0" />
+                        </a:spcBef>
+                        <a:spcAft>
+                          <a:spcPts val="600" />
+                        </a:spcAft>
+                        <a:buClrTx />
+                        <a:buSzTx />
+                        <a:buFontTx />
+                        <a:buNone />
+                        <a:tabLst />
+                        <a:defRPr />
+                      </a:pPr>
+                      <a:endParaRPr lang="en-GB" sz="1600" kern="1200" spc="-20" dirty="0">
+                        <a:solidFill>
+                          <a:schemeClr val="tx1">
+                            <a:lumMod val="85000" />
+                            <a:lumOff val="15000" />
+                          </a:schemeClr>
+                        </a:solidFill>
+                        <a:latin typeface="+mj-lt" />
+                        <a:ea typeface="+mn-ea" />
+                        <a:cs typeface="+mn-cs" />
+                      </a:endParaRPr>
+                    </a:p>
+                  </a:txBody>
+                  <a:tcPr marL="192000" marR="192000" anchor="ctr">
+                    <a:lnL w="19050" cap="flat" cmpd="sng" algn="ctr">
+                      <a:noFill />
+                      <a:prstDash val="solid" />
+                      <a:round />
+                      <a:headEnd type="none" w="med" len="med" />
+                      <a:tailEnd type="none" w="med" len="med" />
+                    </a:lnL>
+                    <a:lnR w="12700" cmpd="sng">
+                      <a:noFill />
+                    </a:lnR>
+                    <a:lnT w="57150" cap="flat" cmpd="sng" algn="ctr">
+                      <a:solidFill>
+                        <a:schemeClr val="bg1" />
+                      </a:solidFill>
+                      <a:prstDash val="solid" />
+                      <a:round />
+                      <a:headEnd type="none" w="med" len="med" />
+                      <a:tailEnd type="none" w="med" len="med" />
+                    </a:lnT>
+                    <a:lnB w="12700" cmpd="sng">
+                      <a:noFill />
+                    </a:lnB>
+                    <a:lnTlToBr w="12700" cmpd="sng">
+                      <a:noFill />
+                      <a:prstDash val="solid" />
+                    </a:lnTlToBr>
+                    <a:lnBlToTr w="12700" cmpd="sng">
+                      <a:noFill />
+                      <a:prstDash val="solid" />
+                    </a:lnBlToTr>
+                    <a:solidFill>
+                      <a:schemeClr val="accent1" />
+                    </a:solidFill>
+                  </a:tcPr>
+                </a:tc>
+                <a:extLst>
+                  <a:ext uri="{0D108BD9-81ED-4DB2-BD59-A6C34878D82A}">
+                    <a16:rowId xmlns:a16="http://schemas.microsoft.com/office/drawing/2014/main"
+                      val="10003" />
+                  </a:ext>
+                </a:extLst>
+              </a:tr>
+            </a:tbl>
+          </a:graphicData>
+        </a:graphic>
+      </p:graphicFrame>
+      <p:sp>
+        <p:nvSpPr>
+          <p:cNvPr id="9" name="Text Placeholder 2">
+            <a:extLst>
+              <a:ext uri="{FF2B5EF4-FFF2-40B4-BE49-F238E27FC236}">
+                <a16:creationId xmlns:a16="http://schemas.microsoft.com/office/drawing/2014/main"
+                  id="{077E441D-7CFB-3297-A6BF-FF601C029EF0}" />
+              </a:ext>
+            </a:extLst>
+          </p:cNvPr>
+          <p:cNvSpPr>
+            <a:spLocks noGrp="1" />
+          </p:cNvSpPr>
+          <p:nvPr>
+            <p:ph type="body" idx="83" hasCustomPrompt="1" />
+          </p:nvPr>
+        </p:nvSpPr>
+        <p:spPr>
+          <a:xfrm>
+            <a:off x="516005" y="1788689" />
+            <a:ext cx="3442040" cy="553998" />
+          </a:xfrm>
+        </p:spPr>
+        <p:txBody>
+          <a:bodyPr wrap="square" anchor="t" anchorCtr="0">
+            <a:spAutoFit />
+          </a:bodyPr>
+          <a:lstStyle>
+            <a:lvl1pPr marL="0" indent="0" algn="l">
+              <a:lnSpc>
+                <a:spcPct val="100000" />
+              </a:lnSpc>
+              <a:spcAft>
+                <a:spcPts val="0" />
+              </a:spcAft>
+              <a:buNone />
+              <a:defRPr sz="1800" b="1" spc="0" baseline="0">
+                <a:solidFill>
+                  <a:schemeClr val="tx2" />
+                </a:solidFill>
+              </a:defRPr>
+            </a:lvl1pPr>
+            <a:lvl2pPr marL="457200" indent="0">
+              <a:buNone />
+              <a:defRPr sz="2000" b="1" />
+            </a:lvl2pPr>
+            <a:lvl3pPr marL="914400" indent="0">
+              <a:buNone />
+              <a:defRPr sz="1800" b="1" />
+            </a:lvl3pPr>
+            <a:lvl4pPr marL="1371600" indent="0">
+              <a:buNone />
+              <a:defRPr sz="1600" b="1" />
+            </a:lvl4pPr>
+            <a:lvl5pPr marL="1828800" indent="0">
+              <a:buNone />
+              <a:defRPr sz="1600" b="1" />
+            </a:lvl5pPr>
+            <a:lvl6pPr marL="2286000" indent="0">
+              <a:buNone />
+              <a:defRPr sz="1600" b="1" />
+            </a:lvl6pPr>
+            <a:lvl7pPr marL="2743200" indent="0">
+              <a:buNone />
+              <a:defRPr sz="1600" b="1" />
+            </a:lvl7pPr>
+            <a:lvl8pPr marL="3200400" indent="0">
+              <a:buNone />
+              <a:defRPr sz="1600" b="1" />
+            </a:lvl8pPr>
+            <a:lvl9pPr marL="3657600" indent="0">
+              <a:buNone />
+              <a:defRPr sz="1600" b="1" />
+            </a:lvl9pPr>
+          </a:lstStyle>
+          <a:p>
+            <a:pPr lvl="0" />
+            <a:r>
+              <a:rPr lang="en-GB" dirty="0" />
+              <a:t>Header </a:t>
+            </a:r>
+          </a:p>
+          <a:p>
+            <a:pPr lvl="0" />
+            <a:r>
+              <a:rPr lang="en-GB" dirty="0" />
+              <a:t>(second line)</a:t>
+            </a:r>
+          </a:p>
+        </p:txBody>
+      </p:sp>
+      <p:sp>
+        <p:nvSpPr>
+          <p:cNvPr id="11" name="Text Placeholder 2">
+            <a:extLst>
+              <a:ext uri="{FF2B5EF4-FFF2-40B4-BE49-F238E27FC236}">
+                <a16:creationId xmlns:a16="http://schemas.microsoft.com/office/drawing/2014/main"
+                  id="{BE233C79-95A7-E719-B761-6E33CDB71352}" />
+              </a:ext>
+            </a:extLst>
+          </p:cNvPr>
+          <p:cNvSpPr>
+            <a:spLocks noGrp="1" />
+          </p:cNvSpPr>
+          <p:nvPr>
+            <p:ph type="body" idx="84" hasCustomPrompt="1" />
+          </p:nvPr>
+        </p:nvSpPr>
+        <p:spPr>
+          <a:xfrm>
+            <a:off x="4387813" y="1788689" />
+            <a:ext cx="3442040" cy="553998" />
+          </a:xfrm>
+        </p:spPr>
+        <p:txBody>
+          <a:bodyPr wrap="square" anchor="t" anchorCtr="0">
+            <a:spAutoFit />
+          </a:bodyPr>
+          <a:lstStyle>
+            <a:lvl1pPr marL="0" indent="0" algn="l">
+              <a:lnSpc>
+                <a:spcPct val="100000" />
+              </a:lnSpc>
+              <a:spcAft>
+                <a:spcPts val="0" />
+              </a:spcAft>
+              <a:buNone />
+              <a:defRPr sz="1800" b="1" spc="0" baseline="0">
+                <a:solidFill>
+                  <a:schemeClr val="bg1" />
+                </a:solidFill>
+              </a:defRPr>
+            </a:lvl1pPr>
+            <a:lvl2pPr marL="457200" indent="0">
+              <a:buNone />
+              <a:defRPr sz="2000" b="1" />
+            </a:lvl2pPr>
+            <a:lvl3pPr marL="914400" indent="0">
+              <a:buNone />
+              <a:defRPr sz="1800" b="1" />
+            </a:lvl3pPr>
+            <a:lvl4pPr marL="1371600" indent="0">
+              <a:buNone />
+              <a:defRPr sz="1600" b="1" />
+            </a:lvl4pPr>
+            <a:lvl5pPr marL="1828800" indent="0">
+              <a:buNone />
+              <a:defRPr sz="1600" b="1" />
+            </a:lvl5pPr>
+            <a:lvl6pPr marL="2286000" indent="0">
+              <a:buNone />
+              <a:defRPr sz="1600" b="1" />
+            </a:lvl6pPr>
+            <a:lvl7pPr marL="2743200" indent="0">
+              <a:buNone />
+              <a:defRPr sz="1600" b="1" />
+            </a:lvl7pPr>
+            <a:lvl8pPr marL="3200400" indent="0">
+              <a:buNone />
+              <a:defRPr sz="1600" b="1" />
+            </a:lvl8pPr>
+            <a:lvl9pPr marL="3657600" indent="0">
+              <a:buNone />
+              <a:defRPr sz="1600" b="1" />
+            </a:lvl9pPr>
+          </a:lstStyle>
+          <a:p>
+            <a:pPr lvl="0" />
+            <a:r>
+              <a:rPr lang="en-GB" dirty="0" />
+              <a:t>Header </a:t>
+            </a:r>
+          </a:p>
+          <a:p>
+            <a:pPr lvl="0" />
+            <a:r>
+              <a:rPr lang="en-GB" dirty="0" />
+              <a:t>(second line)</a:t>
+            </a:r>
+          </a:p>
+        </p:txBody>
+      </p:sp>
+      <p:sp>
+        <p:nvSpPr>
+          <p:cNvPr id="12" name="Text Placeholder 2">
+            <a:extLst>
+              <a:ext uri="{FF2B5EF4-FFF2-40B4-BE49-F238E27FC236}">
+                <a16:creationId xmlns:a16="http://schemas.microsoft.com/office/drawing/2014/main"
+                  id="{F2D700D5-084A-09E0-F34B-97243ED019CB}" />
+              </a:ext>
+            </a:extLst>
+          </p:cNvPr>
+          <p:cNvSpPr>
+            <a:spLocks noGrp="1" />
+          </p:cNvSpPr>
+          <p:nvPr>
+            <p:ph type="body" idx="85" hasCustomPrompt="1" />
+          </p:nvPr>
+        </p:nvSpPr>
+        <p:spPr>
+          <a:xfrm>
+            <a:off x="8210049" y="1788689" />
+            <a:ext cx="3442040" cy="553998" />
+          </a:xfrm>
+        </p:spPr>
+        <p:txBody>
+          <a:bodyPr wrap="square" anchor="t" anchorCtr="0">
+            <a:spAutoFit />
+          </a:bodyPr>
+          <a:lstStyle>
+            <a:lvl1pPr marL="0" indent="0" algn="l">
+              <a:lnSpc>
+                <a:spcPct val="100000" />
+              </a:lnSpc>
+              <a:spcAft>
+                <a:spcPts val="0" />
+              </a:spcAft>
+              <a:buNone />
+              <a:defRPr sz="1800" b="1" spc="0" baseline="0">
+                <a:solidFill>
+                  <a:schemeClr val="bg1" />
+                </a:solidFill>
+              </a:defRPr>
+            </a:lvl1pPr>
+            <a:lvl2pPr marL="457200" indent="0">
+              <a:buNone />
+              <a:defRPr sz="2000" b="1" />
+            </a:lvl2pPr>
+            <a:lvl3pPr marL="914400" indent="0">
+              <a:buNone />
+              <a:defRPr sz="1800" b="1" />
+            </a:lvl3pPr>
+            <a:lvl4pPr marL="1371600" indent="0">
+              <a:buNone />
+              <a:defRPr sz="1600" b="1" />
+            </a:lvl4pPr>
+            <a:lvl5pPr marL="1828800" indent="0">
+              <a:buNone />
+              <a:defRPr sz="1600" b="1" />
+            </a:lvl5pPr>
+            <a:lvl6pPr marL="2286000" indent="0">
+              <a:buNone />
+              <a:defRPr sz="1600" b="1" />
+            </a:lvl6pPr>
+            <a:lvl7pPr marL="2743200" indent="0">
+              <a:buNone />
+              <a:defRPr sz="1600" b="1" />
+            </a:lvl7pPr>
+            <a:lvl8pPr marL="3200400" indent="0">
+              <a:buNone />
+              <a:defRPr sz="1600" b="1" />
+            </a:lvl8pPr>
+            <a:lvl9pPr marL="3657600" indent="0">
+              <a:buNone />
+              <a:defRPr sz="1600" b="1" />
+            </a:lvl9pPr>
+          </a:lstStyle>
+          <a:p>
+            <a:pPr lvl="0" />
+            <a:r>
+              <a:rPr lang="en-GB" dirty="0" />
+              <a:t>Header </a:t>
+            </a:r>
+          </a:p>
+          <a:p>
+            <a:pPr lvl="0" />
+            <a:r>
+              <a:rPr lang="en-GB" dirty="0" />
+              <a:t>(second line)</a:t>
+            </a:r>
+          </a:p>
+        </p:txBody>
+      </p:sp>
+      <p:sp>
+        <p:nvSpPr>
+          <p:cNvPr id="13" name="Text Placeholder 20">
+            <a:extLst>
+              <a:ext uri="{FF2B5EF4-FFF2-40B4-BE49-F238E27FC236}">
+                <a16:creationId xmlns:a16="http://schemas.microsoft.com/office/drawing/2014/main"
+                  id="{3AD58D75-459D-C811-56ED-DDE134BBFA81}" />
+              </a:ext>
+            </a:extLst>
+          </p:cNvPr>
+          <p:cNvSpPr>
+            <a:spLocks noGrp="1" />
+          </p:cNvSpPr>
+          <p:nvPr>
+            <p:ph type="body" idx="33" />
+          </p:nvPr>
+        </p:nvSpPr>
+        <p:spPr>
+          <a:xfrm>
+            <a:off x="526687" y="2685340" />
+            <a:ext cx="3431358" cy="1037574" />
+          </a:xfrm>
+        </p:spPr>
+        <p:txBody>
+          <a:bodyPr />
+          <a:lstStyle>
+            <a:lvl1pPr>
+              <a:defRPr sz="1200" />
+            </a:lvl1pPr>
+          </a:lstStyle>
+          <a:p>
+            <a:pPr marL="0" indent="0">
+              <a:buNone />
+            </a:pPr>
+            <a:endParaRPr lang="en-GB" sz="1200" dirty="0" />
+          </a:p>
+        </p:txBody>
+      </p:sp>
+      <p:sp>
+        <p:nvSpPr>
+          <p:cNvPr id="14" name="Text Placeholder 20">
+            <a:extLst>
+              <a:ext uri="{FF2B5EF4-FFF2-40B4-BE49-F238E27FC236}">
+                <a16:creationId xmlns:a16="http://schemas.microsoft.com/office/drawing/2014/main"
+                  id="{16EA9668-1883-956E-35AC-8879B37636C3}" />
+              </a:ext>
+            </a:extLst>
+          </p:cNvPr>
+          <p:cNvSpPr>
+            <a:spLocks noGrp="1" />
+          </p:cNvSpPr>
+          <p:nvPr>
+            <p:ph type="body" idx="86" />
+          </p:nvPr>
+        </p:nvSpPr>
+        <p:spPr>
+          <a:xfrm>
+            <a:off x="4398495" y="2685340" />
+            <a:ext cx="3431358" cy="1037574" />
+          </a:xfrm>
+        </p:spPr>
+        <p:txBody>
+          <a:bodyPr />
+          <a:lstStyle>
+            <a:lvl1pPr>
+              <a:defRPr sz="1200" >
+                <a:solidFill>
+                  <a:schemeClr val="bg1" />
+                </a:solidFill>
+              </a:defRPr>
+            </a:lvl1pPr>
+          </a:lstStyle>
+          <a:p>
+            <a:pPr marL="0" indent="0">
+              <a:buNone />
+            </a:pPr>
+            <a:endParaRPr lang="en-GB" sz="1200" dirty="0" />
+          </a:p>
+        </p:txBody>
+      </p:sp>
+      <p:sp>
+        <p:nvSpPr>
+          <p:cNvPr id="15" name="Text Placeholder 20">
+            <a:extLst>
+              <a:ext uri="{FF2B5EF4-FFF2-40B4-BE49-F238E27FC236}">
+                <a16:creationId xmlns:a16="http://schemas.microsoft.com/office/drawing/2014/main"
+                  id="{32BEA1D1-8003-4D85-E292-D629608CA595}" />
+              </a:ext>
+            </a:extLst>
+          </p:cNvPr>
+          <p:cNvSpPr>
+            <a:spLocks noGrp="1" />
+          </p:cNvSpPr>
+          <p:nvPr>
+            <p:ph type="body" idx="87" />
+          </p:nvPr>
+        </p:nvSpPr>
+        <p:spPr>
+          <a:xfrm>
+            <a:off x="8220731" y="2694047" />
+            <a:ext cx="3431358" cy="1037574" />
+          </a:xfrm>
+        </p:spPr>
+        <p:txBody>
+          <a:bodyPr />
+          <a:lstStyle>
+            <a:lvl1pPr>
+              <a:defRPr sz="1200">
+                <a:solidFill>
+                  <a:schemeClr val="bg1" />
+                </a:solidFill>
+              </a:defRPr>
+            </a:lvl1pPr>
+          </a:lstStyle>
+          <a:p>
+            <a:pPr marL="0" indent="0">
+              <a:buNone />
+            </a:pPr>
+            <a:endParaRPr lang="en-GB" sz="1200" dirty="0" />
+          </a:p>
+        </p:txBody>
+      </p:sp>
+      <p:sp>
+        <p:nvSpPr>
+          <p:cNvPr id="16" name="Text Placeholder 20">
+            <a:extLst>
+              <a:ext uri="{FF2B5EF4-FFF2-40B4-BE49-F238E27FC236}">
+                <a16:creationId xmlns:a16="http://schemas.microsoft.com/office/drawing/2014/main"
+                  id="{2527BD06-BA96-F6B9-45C5-B2E4260A8FEC}" />
+              </a:ext>
+            </a:extLst>
+          </p:cNvPr>
+          <p:cNvSpPr>
+            <a:spLocks noGrp="1" />
+          </p:cNvSpPr>
+          <p:nvPr>
+            <p:ph type="body" idx="88" />
+          </p:nvPr>
+        </p:nvSpPr>
+        <p:spPr>
+          <a:xfrm>
+            <a:off x="535394" y="4039524" />
+            <a:ext cx="3431358" cy="1037574" />
+          </a:xfrm>
+        </p:spPr>
+        <p:txBody>
+          <a:bodyPr />
+          <a:lstStyle>
+            <a:lvl1pPr>
+              <a:defRPr sz="1200" />
+            </a:lvl1pPr>
+          </a:lstStyle>
+          <a:p>
+            <a:pPr marL="0" indent="0">
+              <a:buNone />
+            </a:pPr>
+            <a:endParaRPr lang="en-GB" sz="1200" dirty="0" />
+          </a:p>
+        </p:txBody>
+      </p:sp>
+      <p:sp>
+        <p:nvSpPr>
+          <p:cNvPr id="17" name="Text Placeholder 20">
+            <a:extLst>
+              <a:ext uri="{FF2B5EF4-FFF2-40B4-BE49-F238E27FC236}">
+                <a16:creationId xmlns:a16="http://schemas.microsoft.com/office/drawing/2014/main"
+                  id="{3B5004D5-D629-2DA3-C93D-D1623644530C}" />
+              </a:ext>
+            </a:extLst>
+          </p:cNvPr>
+          <p:cNvSpPr>
+            <a:spLocks noGrp="1" />
+          </p:cNvSpPr>
+          <p:nvPr>
+            <p:ph type="body" idx="89" />
+          </p:nvPr>
+        </p:nvSpPr>
+        <p:spPr>
+          <a:xfrm>
+            <a:off x="4407202" y="4039524" />
+            <a:ext cx="3431358" cy="1037574" />
+          </a:xfrm>
+        </p:spPr>
+        <p:txBody>
+          <a:bodyPr />
+          <a:lstStyle>
+            <a:lvl1pPr>
+              <a:defRPr sz="1200">
+                <a:solidFill>
+                  <a:schemeClr val="bg1" />
+                </a:solidFill>
+              </a:defRPr>
+            </a:lvl1pPr>
+          </a:lstStyle>
+          <a:p>
+            <a:pPr marL="0" indent="0">
+              <a:buNone />
+            </a:pPr>
+            <a:endParaRPr lang="en-GB" sz="1200" dirty="0" />
+          </a:p>
+        </p:txBody>
+      </p:sp>
+      <p:sp>
+        <p:nvSpPr>
+          <p:cNvPr id="18" name="Text Placeholder 20">
+            <a:extLst>
+              <a:ext uri="{FF2B5EF4-FFF2-40B4-BE49-F238E27FC236}">
+                <a16:creationId xmlns:a16="http://schemas.microsoft.com/office/drawing/2014/main"
+                  id="{153AE787-66DE-A5FE-1718-E036C7B2C8EF}" />
+              </a:ext>
+            </a:extLst>
+          </p:cNvPr>
+          <p:cNvSpPr>
+            <a:spLocks noGrp="1" />
+          </p:cNvSpPr>
+          <p:nvPr>
+            <p:ph type="body" idx="90" />
+          </p:nvPr>
+        </p:nvSpPr>
+        <p:spPr>
+          <a:xfrm>
+            <a:off x="8229438" y="4048231" />
+            <a:ext cx="3431358" cy="1037574" />
+          </a:xfrm>
+        </p:spPr>
+        <p:txBody>
+          <a:bodyPr />
+          <a:lstStyle>
+            <a:lvl1pPr>
+              <a:defRPr sz="1200">
+                <a:solidFill>
+                  <a:schemeClr val="bg1" />
+                </a:solidFill>
+              </a:defRPr>
+            </a:lvl1pPr>
+          </a:lstStyle>
+          <a:p>
+            <a:pPr marL="0" indent="0">
+              <a:buNone />
+            </a:pPr>
+            <a:endParaRPr lang="en-GB" sz="1200" dirty="0" />
+          </a:p>
+        </p:txBody>
+      </p:sp>
+      <p:sp>
+        <p:nvSpPr>
+          <p:cNvPr id="19" name="Text Placeholder 20">
+            <a:extLst>
+              <a:ext uri="{FF2B5EF4-FFF2-40B4-BE49-F238E27FC236}">
+                <a16:creationId xmlns:a16="http://schemas.microsoft.com/office/drawing/2014/main"
+                  id="{99358F69-B4AC-AA58-7407-515269710DB8}" />
+              </a:ext>
+            </a:extLst>
+          </p:cNvPr>
+          <p:cNvSpPr>
+            <a:spLocks noGrp="1" />
+          </p:cNvSpPr>
+          <p:nvPr>
+            <p:ph type="body" idx="91" />
+          </p:nvPr>
+        </p:nvSpPr>
+        <p:spPr>
+          <a:xfrm>
+            <a:off x="535394" y="5437253" />
+            <a:ext cx="3431358" cy="1037574" />
+          </a:xfrm>
+        </p:spPr>
+        <p:txBody>
+          <a:bodyPr />
+          <a:lstStyle>
+            <a:lvl1pPr>
+              <a:defRPr sz="1200" />
+            </a:lvl1pPr>
+          </a:lstStyle>
+          <a:p>
+            <a:pPr marL="0" indent="0">
+              <a:buNone />
+            </a:pPr>
+            <a:endParaRPr lang="en-GB" sz="1200" dirty="0" />
+          </a:p>
+        </p:txBody>
+      </p:sp>
+      <p:sp>
+        <p:nvSpPr>
+          <p:cNvPr id="20" name="Text Placeholder 20">
+            <a:extLst>
+              <a:ext uri="{FF2B5EF4-FFF2-40B4-BE49-F238E27FC236}">
+                <a16:creationId xmlns:a16="http://schemas.microsoft.com/office/drawing/2014/main"
+                  id="{EEB914C6-D1B8-76B4-B72F-BDBAA57ABA62}" />
+              </a:ext>
+            </a:extLst>
+          </p:cNvPr>
+          <p:cNvSpPr>
+            <a:spLocks noGrp="1" />
+          </p:cNvSpPr>
+          <p:nvPr>
+            <p:ph type="body" idx="92" />
+          </p:nvPr>
+        </p:nvSpPr>
+        <p:spPr>
+          <a:xfrm>
+            <a:off x="4407202" y="5437253" />
+            <a:ext cx="3431358" cy="1037574" />
+          </a:xfrm>
+        </p:spPr>
+        <p:txBody>
+          <a:bodyPr />
+          <a:lstStyle>
+            <a:lvl1pPr>
+              <a:defRPr sz="1200">
+                <a:solidFill>
+                  <a:schemeClr val="bg1" />
+                </a:solidFill>
+              </a:defRPr>
+            </a:lvl1pPr>
+          </a:lstStyle>
+          <a:p>
+            <a:pPr marL="0" indent="0">
+              <a:buNone />
+            </a:pPr>
+            <a:endParaRPr lang="en-GB" sz="1200" dirty="0" />
+          </a:p>
+        </p:txBody>
+      </p:sp>
+      <p:sp>
+        <p:nvSpPr>
+          <p:cNvPr id="21" name="Text Placeholder 20">
+            <a:extLst>
+              <a:ext uri="{FF2B5EF4-FFF2-40B4-BE49-F238E27FC236}">
+                <a16:creationId xmlns:a16="http://schemas.microsoft.com/office/drawing/2014/main"
+                  id="{3724EF1A-9342-DCF9-017D-605DE3CF44C8}" />
+              </a:ext>
+            </a:extLst>
+          </p:cNvPr>
+          <p:cNvSpPr>
+            <a:spLocks noGrp="1" />
+          </p:cNvSpPr>
+          <p:nvPr>
+            <p:ph type="body" idx="93" />
+          </p:nvPr>
+        </p:nvSpPr>
+        <p:spPr>
+          <a:xfrm>
+            <a:off x="8229438" y="5445960" />
+            <a:ext cx="3431358" cy="1037574" />
+          </a:xfrm>
+        </p:spPr>
+        <p:txBody>
+          <a:bodyPr />
+          <a:lstStyle>
+            <a:lvl1pPr>
+              <a:defRPr sz="1200">
+                <a:solidFill>
+                  <a:schemeClr val="bg1" />
+                </a:solidFill>
+              </a:defRPr>
+            </a:lvl1pPr>
+          </a:lstStyle>
+          <a:p>
+            <a:pPr marL="0" indent="0">
+              <a:buNone />
+            </a:pPr>
+            <a:endParaRPr lang="en-GB" sz="1200" dirty="0" />
+          </a:p>
+        </p:txBody>
+      </p:sp>
+      <p:sp>
+        <p:nvSpPr>
+          <p:cNvPr id="23" name="Title 3">
+            <a:extLst>
+              <a:ext uri="{FF2B5EF4-FFF2-40B4-BE49-F238E27FC236}">
+                <a16:creationId xmlns:a16="http://schemas.microsoft.com/office/drawing/2014/main"
+                  id="{341DAAA3-EA54-A96B-546A-51E7920E3267}" />
+              </a:ext>
+            </a:extLst>
+          </p:cNvPr>
+          <p:cNvSpPr>
+            <a:spLocks noGrp="1" />
+          </p:cNvSpPr>
+          <p:nvPr>
+            <p:ph type="title" />
+          </p:nvPr>
+        </p:nvSpPr>
+        <p:spPr>
+          <a:xfrm>
+            <a:off x="327212" y="790573" />
+            <a:ext cx="11537580" cy="512961" />
+          </a:xfrm>
+        </p:spPr>
+        <p:txBody>
+          <a:bodyPr />
+          <a:lstStyle>
+            <a:lvl1pPr>
+              <a:defRPr />
+            </a:lvl1pPr>
+          </a:lstStyle>
+          <a:p>
+            <a:endParaRPr lang="en-GB" dirty="0" />
+          </a:p>
+        </p:txBody>
+      </p:sp>
+    </p:spTree>
+    <p:extLst>
+      <p:ext uri="{BB962C8B-B14F-4D97-AF65-F5344CB8AC3E}">
+        <p14:creationId xmlns:p14="http://schemas.microsoft.com/office/powerpoint/2010/main"
+          val="4109622162" />
+      </p:ext>
+    </p:extLst>
+  </p:cSld>
+  <p:clrMapOvr>
+    <a:masterClrMapping />
+  </p:clrMapOvr>
+</p:sldLayout>


### PR DESCRIPTION
- [COLL-7290: Remove duplicate slide number on heading_text slide](https://futurefoundation.atlassian.net/browse/COLL-7290)
- [COLL-7291: 2 column chart image sizing](https://futurefoundation.atlassian.net/browse/COLL-7291)
- [COLL-7292: 3 column component title should be full-width](https://futurefoundation.atlassian.net/browse/COLL-7292)
- [COLL-7288: Change what will happen next font size](https://futurefoundation.atlassian.net/browse/COLL-7288)
- [COLL-7289: Change background colour of screenshot component slides](https://futurefoundation.atlassian.net/browse/COLL-7289)
- [COLL-7286: Intro slide changes](https://futurefoundation.atlassian.net/browse/COLL-7286)
  - COLL-7286: Increase size of subtitle text box on intro slide
  - COLL-7286: Disable autofit on intro slide subtitle
    - This needs testing in powerpoint as I do not believe keynote respects this property
  - COLL-7286: Reduce intro slide title font size
  - COLL-7286: Replace gradient on intro slide
  - COLL-7286: Remove white line from logo on intro slide
- [COLL-7298: Add Trend Summary Slide](https://futurefoundation.atlassian.net/jira/software/c/projects/COLL/boards/21?selectedIssue=COLL-7298)
- [COLL-7297: Use different slide for Image and Text vs no Image and Text](https://futurefoundation.atlassian.net/jira/software/c/projects/COLL/boards/21?selectedIssue=COLL-7297)