### PR TITLE
Improve logic for switching between FFTrendTextWithImage and FFTrendTextLeftImageRight

### DIFF
--- a/lib/powerpoint/presentation.rb
+++ b/lib/powerpoint/presentation.rb
@@ -60,7 +60,14 @@ module Powerpoint
 
     def add_ff_heading_text_slide(title, content, image_paths, links = [])
       @slides << if image_paths&.any?
-        if extract_ooxml_text(content).length > 0
+        text_content = extract_ooxml_text(content)
+        text_dimensions = text_content ?
+          measure_text(text_content) :
+          { width: 0, height: 0 }
+        # From text with image slide template
+        max_text_width = pt_to_pixle(11570400)
+        max_text_height = pt_to_pixle(193899)
+        if text_dimensions[:width] > max_text_width || text_dimensions[:height] > max_text_height
           Powerpoint::Slide::FFTrendTextLeftImageRight.new(
             presentation: self,
             title: title,
@@ -72,7 +79,8 @@ module Powerpoint
           Powerpoint::Slide::FFTrendTextWithImage.new(
             presentation: self,
             title: title,
-            content: "",
+            # If content is empty, use empty string to ensure it is not nil
+            content: text_content.length > 0 ? content : '',
             image_path: image_paths[0],
             links: links
           )

--- a/lib/powerpoint/presentation.rb
+++ b/lib/powerpoint/presentation.rb
@@ -66,7 +66,7 @@ module Powerpoint
           { width: 0, height: 0 }
         # From text with image slide template
         max_text_width = pt_to_pixle(11570400)
-        max_text_height = pt_to_pixle(193899)
+        max_text_height = pt_to_pixle(203200)
         if text_dimensions[:width] > max_text_width || text_dimensions[:height] > max_text_height
           Powerpoint::Slide::FFTrendTextLeftImageRight.new(
             presentation: self,

--- a/lib/powerpoint/presentation.rb
+++ b/lib/powerpoint/presentation.rb
@@ -61,9 +61,8 @@ module Powerpoint
     def add_ff_heading_text_slide(title, content, image_paths, links = [])
       @slides << if image_paths&.any?
         text_content = extract_ooxml_text(content)
-        text_dimensions = text_content ?
-          measure_text(text_content) :
-          { width: 0, height: 0 }
+        # measure_text handles blank text
+        text_dimensions = measure_text(text_content)
         # From text with image slide template
         max_text_width = pt_to_pixle(11570400)
         max_text_height = pt_to_pixle(203200)

--- a/lib/powerpoint/presentation.rb
+++ b/lib/powerpoint/presentation.rb
@@ -60,7 +60,7 @@ module Powerpoint
 
     def add_ff_heading_text_slide(title, content, image_paths, links = [])
       @slides << if image_paths&.any?
-        if content.length > 0
+        if extract_ooxml_text(content).length > 0
           Powerpoint::Slide::FFTrendTextLeftImageRight.new(
             presentation: self,
             title: title,
@@ -73,7 +73,7 @@ module Powerpoint
             presentation: self,
             title: title,
             content: "",
-            image_paths: image_paths,
+            image_path: image_paths[0],
             links: links
           )
         end

--- a/lib/powerpoint/util.rb
+++ b/lib/powerpoint/util.rb
@@ -111,15 +111,24 @@ module Powerpoint
         ooxml = Nokogiri::XML.fragment(ooxml)
       end
 
-      if ooxml.name == 'text'
-        ooxml.text
-      elsif ooxml.children.any?
-        ooxml.children.filter_map { |child|
-          extract_ooxml_text(child).gsub(/[[:space:]]/, ' ').strip.presence
-        }.join("\n")
-      else
-        ''
+      extract_text = -> (node) do
+        if node.name == 'a:p'
+          text = node.text.gsub(/\u00A0/, ' ').strip
+          if text
+            text
+          else
+            nil
+          end
+        elsif node.children.any?
+          node.children.filter_map { |child|
+            extract_text.call(child)
+          }.join("\n")
+        else
+          ''
+        end
       end
+
+      extract_text.call(ooxml).strip
     end
 
     def measure_text(
@@ -140,12 +149,18 @@ module Powerpoint
       label.font_style = font_style
       label.font_weight = font_weight
       label.gravity = Magick::CenterGravity
-      label.text(0, 0, text)
-      metrics = label.get_type_metrics(text)
-      width = metrics.width
-      height = metrics.height
 
-      { width: width, height: height }
+      text.split(/\n/).reduce({ width: 0, height: 0 }) do |d, line|
+        label.text(0, 0, text)
+        metrics = label.get_type_metrics(text)
+        width = metrics.width
+        height = metrics.height
+
+        {
+          width: [d[:width], width].max,
+          height: d[:height] + height
+        }
+      end
     end
   end
 end

--- a/lib/powerpoint/util.rb
+++ b/lib/powerpoint/util.rb
@@ -121,5 +121,31 @@ module Powerpoint
         ''
       end
     end
+
+    def measure_text(
+      text,
+      font_family: 'Arial',
+      font_size: 14,
+      font_style: Magick::NormalStyle,
+      font_weight: Magick::NormalWeight
+    )
+      unless text && text.length > 0
+        return { width: 0, height: 0 }
+      end
+
+      label = Magick::Draw.new
+      label.font = font_family
+      label.pointsize = font_size
+      label.text_antialias(true)
+      label.font_style = font_style
+      label.font_weight = font_weight
+      label.gravity = Magick::CenterGravity
+      label.text(0, 0, text)
+      metrics = label.get_type_metrics(text)
+      width = metrics.width
+      height = metrics.height
+
+      { width: width, height: height }
+    end
   end
 end

--- a/lib/powerpoint/util.rb
+++ b/lib/powerpoint/util.rb
@@ -105,5 +105,21 @@ module Powerpoint
     def remove_newlines(ooxml)
       ooxml.gsub("\n","")
     end
+
+    def extract_ooxml_text(ooxml)
+      if ooxml.is_a?(String)
+        ooxml = Nokogiri::XML.fragment(ooxml)
+      end
+
+      if ooxml.name == 'text'
+        ooxml.text
+      elsif ooxml.children.any?
+        ooxml.children.filter_map { |child|
+          extract_ooxml_text(child).gsub(/[[:space:]]/, ' ').strip.presence
+        }.join("\n")
+      else
+        ''
+      end
+    end
   end
 end

--- a/lib/powerpoint/util.rb
+++ b/lib/powerpoint/util.rb
@@ -111,24 +111,22 @@ module Powerpoint
         ooxml = Nokogiri::XML.fragment(ooxml)
       end
 
-      extract_text = -> (node) do
-        if node.name == 'a:p'
-          text = node.text.gsub(/\u00A0/, ' ').strip
-          if text
-            text
-          else
-            nil
-          end
-        elsif node.children.any?
-          node.children.filter_map { |child|
-            extract_text.call(child)
-          }.join("\n")
-        else
-          ''
-        end
-      end
+      if ooxml.children.any?
+        child_text = ooxml.children.map { |child|
+          str = extract_ooxml_text(child).gsub(/[[:space:]]/, ' ').strip
+          str || ''
+        }
 
-      extract_text.call(ooxml).strip
+        # If paragraph, inline text
+        # Otherwise, join with newlines
+        if ooxml.name == 'a:p'
+          child_text.reject { |str| str.empty? }.join(' ')
+        else
+          child_text.join("\n")
+        end
+      else
+        ooxml.text
+      end
     end
 
     def measure_text(

--- a/lib/powerpoint/views/collision-2025/ff_text_with_image_slide.xml.erb
+++ b/lib/powerpoint/views/collision-2025/ff_text_with_image_slide.xml.erb
@@ -94,7 +94,7 @@
         <p:spPr>
           <a:xfrm>
             <a:off x="327211" y="1349679" />
-            <a:ext cx="11570400" cy="193899" />
+            <a:ext cx="11570400" cy="203200" />
           </a:xfrm>
         </p:spPr>
         <p:txBody>


### PR DESCRIPTION
### [COLL-7297: Where text component contains an image, map to text slide (rather than image and description)](https://futurefoundation.atlassian.net/browse/COLL-7297)

- **Enhanced Slide Layout Logic Based on Text Dimensions**
  - Replaced simple content length check with a more accurate measurement of text width and height.
  - Added logic to switch to `FFTrendTextLeftImageRight` layout only if text exceeds layout constraints.

- **Introduced `extract_ooxml_text` Utility Method**
  - Parses and extracts plain text from OOXML content using `Nokogiri`.
  - Strips whitespace and joins nested elements intelligently.

- **Added `measure_text` Utility Method**
  - Uses RMagick to calculate rendered text width and height.
  - Supports configurable font family, size, style, and weight.

- **Improved Fallback Behavior for Empty Content**
  - Ensures fallback to `FFTrendTextWithImage` slide when text fits within layout.
  - Ensures non-nil, empty string content is passed to prevent errors.

- **Increased Text Container Height in Template**
  - Increase container size to match actual rendered height of a single line of text.

```mermaid
graph TD
    A["add_ff_heading_text_slide"] --> B{"image_paths.any?"}
    B -- No --> Z["Use FFTrendHeadingText"]
    B -- Yes --> C["extract_ooxml_text(content)"]
    C --> D["measure_text(text_content)"]
    D --> E{"Text dimensions exceed layout?"}
    E -- Yes --> F["Use FFTrendTextLeftImageRight"]
    E -- No --> G["Use FFTrendTextWithImage"]
```

This PR comment is a  certified free-range ChatGPT product. It was mostly correct. It has been edited by a local, farm-sourced human.
