### PR TITLE
COLL-7393: Fix error when using intro slide with quotes in title

### DIFF
--- a/lib/powerpoint/views/collision-2025/ff_trend_intro_slide.xml.erb
+++ b/lib/powerpoint/views/collision-2025/ff_trend_intro_slide.xml.erb
@@ -27,7 +27,7 @@
       <p:pic>
         <p:nvPicPr>
           <p:cNvPr id="11" name="Picture 10"
-            descr="<%= title ? title.strip.encode(:xml => :text) : nil %>">
+            descr=<%= title ? title.strip.encode(:xml => :attr) : '""' %>>
             <a:extLst>
               <a:ext uri="{FF2B5EF4-FFF2-40B4-BE49-F238E27FC236}">
                 <a16:creationId xmlns:a16="http://schemas.microsoft.com/office/drawing/2014/main"


### PR DESCRIPTION
### [COLL-7393: Using quotation marks in content titles break pptx downloads](https://futurefoundation.atlassian.net/browse/COLL-7393)
Change to `:attr` XML encoding
- Quotes in string are translated to `&quot;`
- Output is wrapped in double quotes automatically
```rb
'Test "string"'.encode(xml: :attr) # => '"Test &quot;string&quot;"'
```